### PR TITLE
Don't blacklist an app version because the app started in background

### DIFF
--- a/src/ios/WebAppLocalServer.swift
+++ b/src/ios/WebAppLocalServer.swift
@@ -106,7 +106,8 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
       startupTimeoutInterval =  NSTimeInterval(startupTimeoutMilliseconds / 1000)
     }
 
-    if !isTesting {
+    if !isTesting &&
+       UIApplication.sharedApplication().applicationState == UIApplicationState.Active {
       startupTimer = METTimer(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) { [weak self] in
         NSLog("App startup timed out, reverting to last known good version")
         self?.revertToLastKnownGoodVersion()


### PR DESCRIPTION
On iOS the web app local server is careful to avoid blacklisting the app version just because the app transitioned into the background and Meteor startup didn't complete for that reason.

However, it's also possible for an app in iOS to *start* in the background when it receives a notification. 

(See for example [URLSessionDidFinishEventsForBackgroundURLSession](https://developer.apple.com/reference/foundation/nsurlsessiondelegate/1617185-urlsessiondidfinisheventsforback?language=objc)).

This isn't caught by the "app did enter background" event because that's only called when the app *transitions* to the background.

This change adds a check so that the startup timer is only started if the app is in the foreground, avoiding blacklisting the app version because the app started in the background.

