### PR TITLE
Swift 3 updates

### DIFF
--- a/src/ios/Asset.swift
+++ b/src/ios/Asset.swift
@@ -1,8 +1,8 @@
 struct Asset {
   let bundle: AssetBundle
   let filePath: String
-  var fileURL: NSURL {
-    return bundle.directoryURL.URLByAppendingPathComponent(filePath,
+  var fileURL: URL {
+    return bundle.directoryURL.appendingPathComponent(filePath,
       isDirectory: false)
   }
   let URLPath: String

--- a/src/ios/AssetBundle.swift
+++ b/src/ios/AssetBundle.swift
@@ -5,44 +5,44 @@ private let configJSONRegEx = try! NSRegularExpression(
 
 /// Load the runtime config by extracting and parsing
 /// `__meteor_runtime_config__` from index.html
-func loadRuntimeConfigFromIndexFileAtURL(fileURL: NSURL) throws -> AssetBundle.RuntimeConfig {
+func loadRuntimeConfigFromIndexFileAtURL(_ fileURL: URL) throws -> AssetBundle.RuntimeConfig {
   do {
-    let indexFileString = try NSString(contentsOfURL: fileURL, encoding: NSUTF8StringEncoding)
+    let indexFileString = try NSString(contentsOf: fileURL, encoding: String.Encoding.utf8.rawValue)
     guard
       let match  = configJSONRegEx.firstMatchInString(indexFileString as String),
-      let configString = (indexFileString.substringWithRange(match.rangeAtIndex(1)) as NSString).stringByRemovingPercentEncoding,
-      let configData = configString.dataUsingEncoding(NSUTF8StringEncoding)
-      else { throw WebAppError.UnsuitableAssetBundle(reason: "Couldn't load runtime config from index file", underlyingError: nil) }
-    return AssetBundle.RuntimeConfig(JSON: try NSJSONSerialization.JSONObjectWithData(configData, options: []) as! JSONObject)
+      let configString = (indexFileString.substring(with: match.rangeAt(1)) as NSString).removingPercentEncoding,
+      let configData = configString.data(using: String.Encoding.utf8)
+      else { throw WebAppError.unsuitableAssetBundle(reason: "Couldn't load runtime config from index file", underlyingError: nil) }
+    return AssetBundle.RuntimeConfig(JSON: try JSONSerialization.jsonObject(with: configData, options: []) as! JSONObject)
   } catch {
-    throw WebAppError.UnsuitableAssetBundle(reason: "Couldn't load runtime config from index file", underlyingError: error)
+    throw WebAppError.unsuitableAssetBundle(reason: "Couldn't load runtime config from index file", underlyingError: error)
   }
 }
 
 final class AssetBundle {
-  private(set) var directoryURL: NSURL
+  fileprivate(set) var directoryURL: URL
 
   let version: String
   let cordovaCompatibilityVersion: String
 
-  private var parentAssetBundle: AssetBundle?
-  private var ownAssetsByURLPath: [String: Asset] = [:]
-  private(set) var indexFile: Asset?
+  fileprivate var parentAssetBundle: AssetBundle?
+  fileprivate var ownAssetsByURLPath: [String: Asset] = [:]
+  fileprivate(set) var indexFile: Asset?
 
   var ownAssets: [Asset] {
     return Array(ownAssetsByURLPath.values)
   }
 
-  convenience init(directoryURL: NSURL, parentAssetBundle: AssetBundle? = nil) throws {
-    let manifestURL = directoryURL.URLByAppendingPathComponent("program.json")
+  convenience init(directoryURL: URL, parentAssetBundle: AssetBundle? = nil) throws {
+    let manifestURL = directoryURL.appendingPathComponent("program.json")
     let manifest = try AssetManifest(fileURL: manifestURL)
     try self.init(directoryURL: directoryURL, manifest: manifest, parentAssetBundle: parentAssetBundle)
   }
 
-  init(directoryURL: NSURL, manifest: AssetManifest, parentAssetBundle: AssetBundle? = nil) throws {
+  init(directoryURL: URL, manifest: AssetManifest, parentAssetBundle: AssetBundle? = nil) throws {
     self.directoryURL = directoryURL
     self.parentAssetBundle = parentAssetBundle
-    
+
     self.version = manifest.version
     self.cordovaCompatibilityVersion = manifest.cordovaCompatibilityVersion
 
@@ -80,65 +80,65 @@ final class AssetBundle {
     self.indexFile = indexFile
   }
 
-  func addAsset(asset: Asset) {
+  func addAsset(_ asset: Asset) {
     ownAssetsByURLPath[asset.URLPath] = asset
   }
 
-  func assetForURLPath(URLPath: String) -> Asset? {
+  func assetForURLPath(_ URLPath: String) -> Asset? {
     return ownAssetsByURLPath[URLPath] ?? parentAssetBundle?.assetForURLPath(URLPath)
   }
 
-  func cachedAssetForURLPath(URLPath: String, hash: String? = nil) -> Asset? {
+  func cachedAssetForURLPath(_ URLPath: String, hash: String? = nil) -> Asset? {
     if let asset = ownAssetsByURLPath[URLPath]
         // If the asset is not cacheable, we require a matching hash
-        where (asset.cacheable || asset.hash != nil) && asset.hash == hash {
+        , (asset.cacheable || asset.hash != nil) && asset.hash == hash {
       return asset
     } else {
       return nil
     }
   }
-  
+
   struct RuntimeConfig {
-    private let JSON: JSONObject
-    
+    fileprivate let JSON: JSONObject
+
     var appId: String? {
       return JSON["appId"] as? String
     }
-    
-    var rootURL: NSURL? {
+
+    var rootURL: URL? {
       if let rootURLString = JSON["ROOT_URL"] as? String {
-        return NSURL(string: rootURLString)
+        return URL(string: rootURLString)
       } else {
         return nil
       }
     }
-    
+
     var autoupdateVersionCordova: String? {
       return JSON["autoupdateVersionCordova"] as? String
     }
   }
-  
+
   /// The runtime config is lazily initialized by loading it from the index.html
   lazy var runtimeConfig: RuntimeConfig? = {
     guard let indexFile = self.indexFile else { return nil }
-    
+
     do {
-      return try loadRuntimeConfigFromIndexFileAtURL(indexFile.fileURL)
+      return try loadRuntimeConfigFromIndexFileAtURL(indexFile.fileURL as URL)
     } catch {
       NSLog("\(error)")
       return nil
     }
   }()
-  
+
   var appId: String? {
     return runtimeConfig?.appId
   }
-  
-  var rootURL: NSURL? {
+
+  var rootURL: URL? {
     return runtimeConfig?.rootURL
   }
 
-  func didMoveToDirectoryAtURL(directoryURL: NSURL) {
+  func didMoveToDirectoryAtURL(_ directoryURL: URL) {
     self.directoryURL = directoryURL
   }
 }

--- a/src/ios/AssetBundleDownloader.swift
+++ b/src/ios/AssetBundleDownloader.swift
@@ -1,50 +1,50 @@
 protocol AssetBundleDownloaderDelegate: class {
-  func assetBundleDownloaderDidFinish(assetBundleDownloader: AssetBundleDownloader)
-  func assetBundleDownloader(assetBundleDownloader: AssetBundleDownloader, didFailWithError error: ErrorType)
+  func assetBundleDownloaderDidFinish(_ assetBundleDownloader: AssetBundleDownloader)
+  func assetBundleDownloader(_ assetBundleDownloader: AssetBundleDownloader, didFailWithError error: Error)
 }
 
-final class AssetBundleDownloader: NSObject, NSURLSessionDelegate, NSURLSessionTaskDelegate, NSURLSessionDataDelegate, NSURLSessionDownloadDelegate, METNetworkReachabilityManagerDelegate {
-  private(set) var configuration: WebAppConfiguration
-  private(set) var assetBundle: AssetBundle
-  private(set) var baseURL: NSURL
+final class AssetBundleDownloader: NSObject, URLSessionDelegate, URLSessionTaskDelegate, URLSessionDataDelegate, URLSessionDownloadDelegate, METNetworkReachabilityManagerDelegate {
+  fileprivate(set) var configuration: WebAppConfiguration
+  fileprivate(set) var assetBundle: AssetBundle
+  fileprivate(set) var baseURL: URL
 
   weak var delegate: AssetBundleDownloaderDelegate?
 
   /// A private serial queue used to synchronize access
-  private let queue: dispatch_queue_t
+  fileprivate let queue: DispatchQueue
 
-  private let fileManager = NSFileManager()
+  fileprivate let fileManager = FileManager()
 
-  private var session: NSURLSession!
+  fileprivate var session: Foundation.URLSession!
 
-  private var missingAssets: Set<Asset>
-  private var assetsDownloadingByTaskIdentifier = [Int: Asset]()
-  private var resumeDataByAsset = [Asset: NSData]()
+  fileprivate var missingAssets: Set<Asset>
+  fileprivate var assetsDownloadingByTaskIdentifier = [Int: Asset]()
+  fileprivate var resumeDataByAsset = [Asset: Data]()
 
-  private var retryStrategy: METRetryStrategy
-  private var numberOfRetryAttempts: UInt = 0
-  private var resumeTimer: METTimer!
-  private var networkReachabilityManager: METNetworkReachabilityManager!
+  fileprivate var retryStrategy: METRetryStrategy
+  fileprivate var numberOfRetryAttempts: UInt = 0
+  fileprivate var resumeTimer: METTimer!
+  fileprivate var networkReachabilityManager: METNetworkReachabilityManager!
 
   enum Status {
-    case Suspended
-    case Running
-    case Waiting
-    case Canceling
-    case Invalid
+    case suspended
+    case running
+    case waiting
+    case canceling
+    case invalid
   }
 
-  private var status: Status = .Suspended
+  fileprivate var status: Status = .suspended
 
-  private var backgroundTask: UIBackgroundTaskIdentifier = UIBackgroundTaskInvalid
+  fileprivate var backgroundTask: UIBackgroundTaskIdentifier = UIBackgroundTaskInvalid
 
-  init(configuration: WebAppConfiguration, assetBundle: AssetBundle, baseURL: NSURL, missingAssets: Set<Asset>) {
+  init(configuration: WebAppConfiguration, assetBundle: AssetBundle, baseURL: URL, missingAssets: Set<Asset>) {
     self.configuration = configuration
     self.assetBundle = assetBundle
     self.baseURL = baseURL
     self.missingAssets = missingAssets
 
-    queue = dispatch_queue_create("com.meteor.webapp.AssetBundleDownloader", nil)
+    queue = DispatchQueue(label: "com.meteor.webapp.AssetBundleDownloader", attributes: [])
 
     retryStrategy = METRetryStrategy()
     retryStrategy.minimumTimeInterval = 0.1
@@ -55,19 +55,19 @@ final class AssetBundleDownloader: NSObject, NSURLSessionDelegate, NSURLSessionT
 
     super.init()
 
-    let sessionConfiguration = NSURLSessionConfiguration.defaultSessionConfiguration()
-    sessionConfiguration.HTTPMaximumConnectionsPerHost = 6
+    let sessionConfiguration = URLSessionConfiguration.default
+    sessionConfiguration.httpMaximumConnectionsPerHost = 6
 
     // Disable the protocol-level local cache, because we make sure to only
     // download changed files, so there is no need to waste additional storage
-    sessionConfiguration.URLCache = nil
-    sessionConfiguration.requestCachePolicy = .ReloadIgnoringLocalCacheData
+    sessionConfiguration.urlCache = nil
+    sessionConfiguration.requestCachePolicy = .reloadIgnoringLocalCacheData
 
-    let operationQueue = NSOperationQueue()
+    let operationQueue = OperationQueue()
     operationQueue.maxConcurrentOperationCount = 1
     operationQueue.underlyingQueue = queue
 
-    session = NSURLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: operationQueue)
+    session = Foundation.URLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: operationQueue)
 
     resumeTimer = METTimer(queue: queue) { [weak self] in
       self?.resume()
@@ -78,50 +78,50 @@ final class AssetBundleDownloader: NSObject, NSURLSessionDelegate, NSURLSessionT
     networkReachabilityManager.delegateQueue = queue
     networkReachabilityManager.startMonitoring()
 
-    NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationWillEnterForeground", name: UIApplicationWillEnterForegroundNotification, object: nil)
+    NotificationCenter.default.addObserver(self, selector: #selector(AssetBundleDownloader.applicationWillEnterForeground), name: NSNotification.Name.UIApplicationWillEnterForeground, object: nil)
   }
 
   deinit {
-    NSNotificationCenter.defaultCenter().removeObserver(self)
+    NotificationCenter.default.removeObserver(self)
   }
 
   func resume() {
-    dispatch_async(queue) {
+    queue.async {
       if self.backgroundTask == UIBackgroundTaskInvalid {
         NSLog("Start downloading assets from bundle with version: \(self.assetBundle.version)")
 
         CDVTimer.start("assetBundleDownload")
 
-        let application = UIApplication.sharedApplication()
-        self.backgroundTask = application.beginBackgroundTaskWithName("AssetBundleDownload") {
+        let application = UIApplication.shared
+        self.backgroundTask = application.beginBackgroundTask(withName: "AssetBundleDownload") {
           // Expiration handler, usually invoked 180 seconds after the app goes
           // into the background
           NSLog("AssetBundleDownload task expired, app is suspending")
-          self.status = .Suspended
+          self.status = .suspended
           self.endBackgroundTask()
         }
       }
 
-      self.status = .Running
+      self.status = .running
 
       let assetsDownloading = Set(self.assetsDownloadingByTaskIdentifier.values)
 
       for asset in self.missingAssets {
         if assetsDownloading.contains(asset) { continue }
 
-        let task: NSURLSessionTask
+        let task: URLSessionTask
 
         // If we have previously stored resume data, use that to recreate the
         // task
-        if let resumeData = self.resumeDataByAsset.removeValueForKey(asset) {
-          task = self.session.downloadTaskWithResumeData(resumeData)
+        if let resumeData = self.resumeDataByAsset.removeValue(forKey: asset) {
+          task = self.session.downloadTask(withResumeData: resumeData)
         } else {
           guard let URL = self.downloadURLForAsset(asset) else {
             self.cancelAndFailWithReason("Invalid URL for asset: \(asset)")
             return
           }
 
-          task = self.session.dataTaskWithURL(URL)
+          task = self.session.dataTask(with: URL)
         }
 
         self.assetsDownloadingByTaskIdentifier[task.taskIdentifier] = asset
@@ -130,25 +130,25 @@ final class AssetBundleDownloader: NSObject, NSURLSessionDelegate, NSURLSessionT
     }
   }
 
-  private func resumeLater() {
-    if status == .Running {
-      let retryInterval = retryStrategy.retryIntervalForNumberOfAttempts(numberOfRetryAttempts)
+  fileprivate func resumeLater() {
+    if status == .running {
+      let retryInterval = retryStrategy.retryIntervalForNumber(ofAttempts: numberOfRetryAttempts)
       NSLog("Will retry resuming downloads after %f seconds", retryInterval);
-      resumeTimer.startWithTimeInterval(retryInterval)
-      numberOfRetryAttempts++
-      status = .Waiting
+      resumeTimer.start(withTimeInterval: retryInterval)
+      numberOfRetryAttempts += 1
+      status = .waiting
     }
   }
 
-  private func downloadURLForAsset(asset: Asset) -> NSURL? {
+  fileprivate func downloadURLForAsset(_ asset: Asset) -> URL? {
     var URLPath = asset.URLPath
 
     // Remove leading / from URL path because the path should be relative to the base URL
     if URLPath.hasPrefix("/") {
-      URLPath = String(asset.URLPath.utf16.dropFirst())
+      URLPath = String(describing: asset.URLPath.utf16.dropFirst())
     }
 
-    guard let URLComponents = NSURLComponents(string: URLPath) else {
+    guard var URLComponents = URLComponents(string: URLPath) else {
       return nil
     }
 
@@ -156,7 +156,7 @@ final class AssetBundleDownloader: NSObject, NSURLSessionDelegate, NSURLSessionT
     // is not found, we add meteor_dont_serve_index=true to the URL unless we
     // are actually downloading the index page.
     if asset.filePath != "index.html" {
-      let queryItem = NSURLQueryItem(name: "meteor_dont_serve_index", value: "true")
+      let queryItem = URLQueryItem(name: "meteor_dont_serve_index", value: "true")
       if var queryItems = URLComponents.queryItems {
         queryItems.append(queryItem)
         URLComponents.queryItems = queryItems
@@ -165,11 +165,11 @@ final class AssetBundleDownloader: NSObject, NSURLSessionDelegate, NSURLSessionT
       }
     }
 
-    return URLComponents.URLRelativeToURL(baseURL)
+    return URLComponents.url(relativeTo: baseURL)
   }
 
-  private func endBackgroundTask() {
-    let application = UIApplication.sharedApplication()
+  fileprivate func endBackgroundTask() {
+    let application = UIApplication.shared
     application.endBackgroundTask(self.backgroundTask)
     self.backgroundTask = UIBackgroundTaskInvalid;
 
@@ -177,30 +177,30 @@ final class AssetBundleDownloader: NSObject, NSURLSessionDelegate, NSURLSessionT
   }
 
   func cancel() {
-    dispatch_sync(queue) {
+    queue.sync {
       self._cancel()
     }
   }
 
-  private func _cancel() {
-    if self.status != .Canceling || self.status == .Invalid {
-      self.status = .Canceling
+  fileprivate func _cancel() {
+    if self.status != .canceling || self.status == .invalid {
+      self.status = .canceling
       self.session.invalidateAndCancel()
       self.endBackgroundTask()
     }
   }
 
-  private func cancelAndFailWithReason(reason: String, underlyingError: ErrorType? = nil) {
-    let error = WebAppError.DownloadFailure(reason: reason, underlyingError: underlyingError)
+  fileprivate func cancelAndFailWithReason(_ reason: String, underlyingError: Error? = nil) {
+    let error = WebAppError.downloadFailure(reason: reason, underlyingError: underlyingError)
     cancelAndFailWithError(error)
   }
 
-  private func cancelAndFailWithError(error: ErrorType) {
+  fileprivate func cancelAndFailWithError(_ error: Error) {
     _cancel()
     delegate?.assetBundleDownloader(self, didFailWithError: error)
   }
 
-  private func didFinish() {
+  fileprivate func didFinish() {
     session.finishTasksAndInvalidate()
     delegate?.assetBundleDownloaderDidFinish(self)
     endBackgroundTask()
@@ -209,39 +209,39 @@ final class AssetBundleDownloader: NSObject, NSURLSessionDelegate, NSURLSessionT
   // MARK: Application State Notifications
 
   func applicationWillEnterForeground() {
-    if status == .Suspended {
+    if status == .suspended {
       resume()
     }
   }
 
   // MARK: METNetworkReachabilityManagerDelegate
 
-  func networkReachabilityManager(reachabilityManager: METNetworkReachabilityManager, didDetectReachabilityStatusChange reachabilityStatus: METNetworkReachabilityStatus) {
+  func networkReachabilityManager(_ reachabilityManager: METNetworkReachabilityManager, didDetectReachabilityStatusChange reachabilityStatus: METNetworkReachabilityStatus) {
 
-    if reachabilityStatus == .Reachable && status == .Waiting {
+    if reachabilityStatus == .reachable && status == .waiting {
       resume()
     }
   }
 
   // MARK: NSURLSessionDelegate
 
-  func URLSession(session: NSURLSession, didBecomeInvalidWithError error: NSError?) {
-    status = .Invalid
+  func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
+    status = .invalid
   }
 
-  func URLSessionDidFinishEventsForBackgroundURLSession(session: NSURLSession) {
+  func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
   }
 
   // MARK: NSURLSessionTaskDelegate
 
-  func URLSession(session: NSURLSession, task: NSURLSessionTask, didCompleteWithError error: NSError?) {
+  func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
     if let error = error {
-      if let asset = assetsDownloadingByTaskIdentifier.removeValueForKey(task.taskIdentifier) {
-        if task is NSURLSessionDownloadTask && status != .Canceling {
+      if let asset = assetsDownloadingByTaskIdentifier.removeValue(forKey: task.taskIdentifier) {
+        if task is URLSessionDownloadTask && status != .canceling {
           NSLog("Download of asset: \(asset) did fail with error: \(error)")
 
           // If there is resume data, we store it and use it to recreate the task later
-          if let resumeData = error.userInfo[NSURLSessionDownloadTaskResumeData] as? NSData {
+          if let resumeData = (error as NSError).userInfo[NSURLSessionDownloadTaskResumeData] as? Data {
             resumeDataByAsset[asset] = resumeData
           }
           resumeLater()
@@ -252,34 +252,34 @@ final class AssetBundleDownloader: NSObject, NSURLSessionDelegate, NSURLSessionT
 
   // MARK: NSURLSessionDataDelegate
 
-  func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didReceiveResponse response: NSURLResponse, completionHandler: (NSURLSessionResponseDisposition) -> Void) {
-    if status == .Canceling { return }
+  func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: (URLSession.ResponseDisposition) -> Void) {
+    if status == .canceling { return }
 
-    guard let response = response as? NSHTTPURLResponse else { return }
+    guard let response = response as? HTTPURLResponse else { return }
 
     if let asset = assetsDownloadingByTaskIdentifier[dataTask.taskIdentifier] {
       do {
         try verifyResponse(response, forAsset: asset)
-        completionHandler(.BecomeDownload)
+        completionHandler(.becomeDownload)
       } catch {
-        completionHandler(.Cancel)
+        completionHandler(.cancel)
         self.cancelAndFailWithError(error)
       }
     }
   }
 
-  func URLSession(session: NSURLSession, dataTask: NSURLSessionDataTask, didBecomeDownloadTask downloadTask: NSURLSessionDownloadTask) {
-    if let asset = assetsDownloadingByTaskIdentifier.removeValueForKey(dataTask.taskIdentifier) {
+  func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didBecome downloadTask: URLSessionDownloadTask) {
+    if let asset = assetsDownloadingByTaskIdentifier.removeValue(forKey: dataTask.taskIdentifier) {
       assetsDownloadingByTaskIdentifier[downloadTask.taskIdentifier] = asset
     }
   }
 
   // MARK: NSURLSessionDownloadDelegate
 
-  func URLSession(session: NSURLSession, downloadTask: NSURLSessionDownloadTask, didResumeAtOffset fileOffset: Int64, expectedTotalBytes: Int64) {
-    if status == .Canceling { return }
+  func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didResumeAtOffset fileOffset: Int64, expectedTotalBytes: Int64) {
+    if status == .canceling { return }
 
-    guard let response = downloadTask.response as? NSHTTPURLResponse else { return }
+    guard let response = downloadTask.response as? HTTPURLResponse else { return }
 
     if let asset = assetsDownloadingByTaskIdentifier[downloadTask.taskIdentifier] {
       do {
@@ -290,9 +290,9 @@ final class AssetBundleDownloader: NSObject, NSURLSessionDelegate, NSURLSessionT
     }
   }
 
-  func URLSession(session: NSURLSession, downloadTask: NSURLSessionDownloadTask, didFinishDownloadingToURL location: NSURL) {
-    if let asset = assetsDownloadingByTaskIdentifier.removeValueForKey(downloadTask.taskIdentifier) {
-      if status == .Canceling { return }
+  func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+    if let asset = assetsDownloadingByTaskIdentifier.removeValue(forKey: downloadTask.taskIdentifier) {
+      if status == .canceling { return }
 
       // We don't have a hash for the index page, so we have to parse the runtime config
       // and compare autoupdateVersionCordova to the version in the manifest to verify
@@ -308,7 +308,7 @@ final class AssetBundleDownloader: NSObject, NSURLSessionDelegate, NSURLSessionT
       }
 
       do {
-        try fileManager.moveItemAtURL(location, toURL: asset.fileURL)
+        try fileManager.moveItem(at: location, to: asset.fileURL as URL)
       } catch {
         self.cancelAndFailWithReason("Could not move downloaded asset", underlyingError: error)
         return
@@ -322,41 +322,41 @@ final class AssetBundleDownloader: NSObject, NSURLSessionDelegate, NSURLSessionT
     }
   }
 
-  private func verifyResponse(response: NSHTTPURLResponse, forAsset asset: Asset) throws {
+  fileprivate func verifyResponse(_ response: HTTPURLResponse, forAsset asset: Asset) throws {
     // A response with a non-success status code should not be considered a succesful download
     if !response.isSuccessful {
-      throw WebAppError.DownloadFailure(reason: "Non-success status code \(response.statusCode) for asset: \(asset)", underlyingError: nil)
+      throw WebAppError.downloadFailure(reason: "Non-success status code \(response.statusCode) for asset: \(asset)", underlyingError: nil)
       // If we have a hash for the asset, and the ETag header also specifies
       // a hash, we compare these to verify if we received the expected asset version
     } else if let expectedHash = asset.hash,
       let ETag = response.allHeaderFields["ETag"] as? String,
       let actualHash = SHA1HashFromETag(ETag)
-      where actualHash != expectedHash {
-        throw WebAppError.DownloadFailure(reason: "Hash mismatch for asset: \(asset)", underlyingError: nil)
+      , actualHash != expectedHash {
+        throw WebAppError.downloadFailure(reason: "Hash mismatch for asset: \(asset)", underlyingError: nil)
     }
   }
-  
-  private func verifyRuntimeConfig(runtimeConfig: AssetBundle.RuntimeConfig) throws {
+
+  fileprivate func verifyRuntimeConfig(_ runtimeConfig: AssetBundle.RuntimeConfig) throws {
     let expectedVersion = assetBundle.version
     if let actualVersion = runtimeConfig.autoupdateVersionCordova
-      where expectedVersion != actualVersion {
-        throw WebAppError.DownloadFailure(reason: "Version mismatch for index page, expected: \(expectedVersion), actual: \(actualVersion)", underlyingError: nil)
+      , expectedVersion != actualVersion {
+        throw WebAppError.downloadFailure(reason: "Version mismatch for index page, expected: \(expectedVersion), actual: \(actualVersion)", underlyingError: nil)
     }
-    
+
     guard let rootURL = runtimeConfig.rootURL else {
-      throw WebAppError.UnsuitableAssetBundle(reason: "Could not find ROOT_URL in downloaded asset bundle", underlyingError: nil)
+      throw WebAppError.unsuitableAssetBundle(reason: "Could not find ROOT_URL in downloaded asset bundle", underlyingError: nil)
     }
-    
+
     if configuration.rootURL?.host != "localhost" && rootURL.host == "localhost" {
-      throw WebAppError.UnsuitableAssetBundle(reason: "ROOT_URL in downloaded asset bundle would change current ROOT_URL to localhost. Make sure ROOT_URL has been configured correctly on the server.", underlyingError: nil)
+      throw WebAppError.unsuitableAssetBundle(reason: "ROOT_URL in downloaded asset bundle would change current ROOT_URL to localhost. Make sure ROOT_URL has been configured correctly on the server.", underlyingError: nil)
     }
-    
+
     guard let appId = runtimeConfig.appId else {
-      throw WebAppError.UnsuitableAssetBundle(reason: "Could not find appId in downloaded asset bundle", underlyingError: nil)
+      throw WebAppError.unsuitableAssetBundle(reason: "Could not find appId in downloaded asset bundle", underlyingError: nil)
     }
-    
+
     if appId != configuration.appId {
-      throw WebAppError.UnsuitableAssetBundle(reason: "appId in downloaded asset bundle does not match current appId. Make sure the server at \(rootURL) is serving the right app.", underlyingError: nil)
+      throw WebAppError.unsuitableAssetBundle(reason: "appId in downloaded asset bundle does not match current appId. Make sure the server at \(rootURL) is serving the right app.", underlyingError: nil)
     }
   }
 }

--- a/src/ios/AssetBundleDownloader.swift
+++ b/src/ios/AssetBundleDownloader.swift
@@ -241,7 +241,7 @@ final class AssetBundleDownloader: NSObject, URLSessionDelegate, URLSessionTaskD
           NSLog("Download of asset: \(asset) did fail with error: \(error)")
 
           // If there is resume data, we store it and use it to recreate the task later
-          if let resumeData = (error as NSError).userInfo[URLSessionDownloadTaskResumeData] as? Data {
+          if let resumeData = (error as NSError).userInfo[NSURLSessionDownloadTaskResumeData] as? Data {
             resumeDataByAsset[asset] = resumeData
           }
           resumeLater()

--- a/src/ios/AssetBundleDownloader.swift
+++ b/src/ios/AssetBundleDownloader.swift
@@ -223,7 +223,7 @@ final class AssetBundleDownloader: NSObject, URLSessionDelegate, URLSessionTaskD
     }
   }
 
-  // MARK: NSURLSessionDelegate
+  // MARK: URLSessionDelegate
 
   func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
     status = .invalid
@@ -232,7 +232,7 @@ final class AssetBundleDownloader: NSObject, URLSessionDelegate, URLSessionTaskD
   func urlSessionDidFinishEvents(forBackgroundURLSession session: URLSession) {
   }
 
-  // MARK: NSURLSessionTaskDelegate
+  // MARK: URLSessionTaskDelegate
 
   func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
     if let error = error {
@@ -241,7 +241,7 @@ final class AssetBundleDownloader: NSObject, URLSessionDelegate, URLSessionTaskD
           NSLog("Download of asset: \(asset) did fail with error: \(error)")
 
           // If there is resume data, we store it and use it to recreate the task later
-          if let resumeData = (error as NSError).userInfo[NSURLSessionDownloadTaskResumeData] as? Data {
+          if let resumeData = (error as NSError).userInfo[URLSessionDownloadTaskResumeData] as? Data {
             resumeDataByAsset[asset] = resumeData
           }
           resumeLater()
@@ -250,9 +250,9 @@ final class AssetBundleDownloader: NSObject, URLSessionDelegate, URLSessionTaskD
     }
   }
 
-  // MARK: NSURLSessionDataDelegate
+  // MARK: URLSessionDataDelegate
 
-  func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: (URLSession.ResponseDisposition) -> Void) {
+  func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive response: URLResponse, completionHandler: @escaping (URLSession.ResponseDisposition) -> Void) {
     if status == .canceling { return }
 
     guard let response = response as? HTTPURLResponse else { return }
@@ -274,7 +274,14 @@ final class AssetBundleDownloader: NSObject, URLSessionDelegate, URLSessionTaskD
     }
   }
 
-  // MARK: NSURLSessionDownloadDelegate
+  @available(iOS 9.0, *)
+  func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didBecome streamTask: URLSessionStreamTask) {
+    if let asset = assetsDownloadingByTaskIdentifier.removeValue(forKey: dataTask.taskIdentifier) {
+      assetsDownloadingByTaskIdentifier[streamTask.taskIdentifier] = asset
+    }
+  }
+
+  // MARK: URLSessionDownloadDelegate
 
   func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didResumeAtOffset fileOffset: Int64, expectedTotalBytes: Int64) {
     if status == .canceling { return }

--- a/src/ios/AssetBundleManager.swift
+++ b/src/ios/AssetBundleManager.swift
@@ -1,14 +1,14 @@
 protocol AssetBundleManagerDelegate: class {
-  func assetBundleManager(assetBundleManager: AssetBundleManager, shouldDownloadBundleForManifest manifest: AssetManifest) -> Bool
-  func assetBundleManager(assetBundleManager: AssetBundleManager, didFinishDownloadingBundle assetBundle: AssetBundle)
-  func assetBundleManager(assetBundleManager: AssetBundleManager, didFailDownloadingBundleWithError error: ErrorType)
+  func assetBundleManager(_ assetBundleManager: AssetBundleManager, shouldDownloadBundleForManifest manifest: AssetManifest) -> Bool
+  func assetBundleManager(_ assetBundleManager: AssetBundleManager, didFinishDownloadingBundle assetBundle: AssetBundle)
+  func assetBundleManager(_ assetBundleManager: AssetBundleManager, didFailDownloadingBundleWithError error: Error)
 }
 
 final class AssetBundleManager: AssetBundleDownloaderDelegate {
   let configuration: WebAppConfiguration
-  
+
   /// The directory used to store downloaded asset bundles
-  let versionsDirectoryURL: NSURL
+  let versionsDirectoryURL: URL
 
   /// The initial asset bundle included in the app bundle
   let initialAssetBundle: AssetBundle
@@ -16,57 +16,57 @@ final class AssetBundleManager: AssetBundleDownloaderDelegate {
   weak var delegate: AssetBundleManagerDelegate?
 
   /// A private serial queue used to synchronize access
-  private let queue: dispatch_queue_t
+  fileprivate let queue: DispatchQueue
 
-  private let fileManager = NSFileManager()
-  private var downloadedAssetBundlesByVersion: [String: AssetBundle]
-  
-  private var session: NSURLSession!
-  
-  private var downloadDirectoryURL: NSURL
-  private var assetBundleDownloader: AssetBundleDownloader?
-  private var partiallyDownloadedAssetBundle: AssetBundle?
+  fileprivate let fileManager = FileManager()
+  fileprivate var downloadedAssetBundlesByVersion: [String: AssetBundle]
+
+  fileprivate var session: URLSession!
+
+  fileprivate var downloadDirectoryURL: URL
+  fileprivate var assetBundleDownloader: AssetBundleDownloader?
+  fileprivate var partiallyDownloadedAssetBundle: AssetBundle?
 
   var isDownloading: Bool {
     return assetBundleDownloader != nil
   }
 
-  init(configuration: WebAppConfiguration, versionsDirectoryURL: NSURL, initialAssetBundle: AssetBundle) {
+  init(configuration: WebAppConfiguration, versionsDirectoryURL: URL, initialAssetBundle: AssetBundle) {
     self.configuration = configuration
     self.versionsDirectoryURL = versionsDirectoryURL
     self.initialAssetBundle = initialAssetBundle
 
-    downloadDirectoryURL = versionsDirectoryURL.URLByAppendingPathComponent("Downloading")
+    downloadDirectoryURL = versionsDirectoryURL.appendingPathComponent("Downloading")
 
-    queue = dispatch_queue_create("com.meteor.webapp.AssetBundleManager", nil)
+    queue = DispatchQueue(label: "com.meteor.webapp.AssetBundleManager", attributes: [])
 
     downloadedAssetBundlesByVersion = [String: AssetBundle]()
     loadDownloadedAssetBundles()
-    
-    let operationQueue = NSOperationQueue()
+
+    let operationQueue = OperationQueue()
     operationQueue.maxConcurrentOperationCount = 1
     operationQueue.underlyingQueue = queue
-    
+
     // We use a separate to download the manifest, so we can use caching
-    // (which we disable for the session we use to download the other files 
+    // (which we disable for the session we use to download the other files
     // in AssetBundleDownloader)
-    session = NSURLSession(configuration: NSURLSessionConfiguration.defaultSessionConfiguration(), delegate: nil, delegateQueue: operationQueue)
+    session = URLSession(configuration: URLSessionConfiguration.default, delegate: nil, delegateQueue: operationQueue)
   }
-  
+
   deinit {
     assetBundleDownloader?.cancel()
   }
 
-  private func loadDownloadedAssetBundles() {
-    let items: [NSURL]
-    items = try! fileManager.contentsOfDirectoryAtURL(versionsDirectoryURL,
-      includingPropertiesForKeys: [NSURLIsDirectoryKey],
-      options: [.SkipsHiddenFiles])
+  fileprivate func loadDownloadedAssetBundles() {
+    let items: [URL]
+    items = try! fileManager.contentsOfDirectory(at: versionsDirectoryURL,
+      includingPropertiesForKeys: [URLResourceKey.isDirectoryKey],
+      options: [.skipsHiddenFiles])
 
     for itemURL in items {
       if itemURL.isDirectory != true { continue }
 
-      guard let version = itemURL.lastPathComponent else { continue }
+      let version = itemURL.lastPathComponent
 
       if version == "PartialDownload" { continue }
       if version == "Downloading" { continue }
@@ -81,30 +81,30 @@ final class AssetBundleManager: AssetBundleDownloaderDelegate {
     }
   }
 
-  func downloadedAssetBundleWithVersion(version: String) -> AssetBundle? {
+  func downloadedAssetBundleWithVersion(_ version: String) -> AssetBundle? {
     var assetBundle: AssetBundle?
-    dispatch_sync(queue) {
+    queue.sync {
       assetBundle = self.downloadedAssetBundlesByVersion[version]
     }
     return assetBundle
   }
 
-  func checkForUpdatesWithBaseURL(baseURL: NSURL) {
-    let manifestURL = NSURL(string: "manifest.json", relativeToURL: baseURL)!
+  func checkForUpdatesWithBaseURL(_ baseURL: URL) {
+    let manifestURL = URL(string: "manifest.json", relativeTo: baseURL)!
 
     NSLog("Start downloading asset manifest from: \(manifestURL)")
 
-    let dataTask = session.dataTaskWithURL(manifestURL) {
+    let dataTask = session.dataTask(with: manifestURL) {
       (data, response, error) in
       guard let data = data else {
-        self.didFailWithError(WebAppError.DownloadFailure(reason: "Error downloading asset manifest", underlyingError: error))
+        self.didFailWithError(WebAppError.downloadFailure(reason: "Error downloading asset manifest", underlyingError: error))
         return
       }
 
-      guard let response = response as? NSHTTPURLResponse else { return }
+      guard let response = response as? HTTPURLResponse else { return }
 
       if !response.isSuccessful {
-        self.didFailWithError(WebAppError.DownloadFailure(reason: "Non-success status code \(response.statusCode) for asset manifest", underlyingError: nil))
+        self.didFailWithError(WebAppError.downloadFailure(reason: "Non-success status code \(response.statusCode) for asset manifest", underlyingError: nil))
         return
       }
 
@@ -120,7 +120,7 @@ final class AssetBundleManager: AssetBundleDownloaderDelegate {
 
       NSLog("Downloaded asset manifest for version: \(version)")
 
-      dispatch_async(self.queue) {
+      self.queue.async {
         if self.assetBundleDownloader?.assetBundle.version == version {
           NSLog("Already downloading asset bundle version: \(version)")
           return
@@ -147,21 +147,21 @@ final class AssetBundleManager: AssetBundleDownloaderDelegate {
           self.didFinishDownloadingAssetBundle(assetBundle)
           return
         }
-        
+
         // Else, get ready to download the new asset bundle
         self.moveExistingDownloadDirectoryIfNeeded()
-        
+
         // Create download directory
         do {
-          try self.fileManager.createDirectoryAtURL(self.downloadDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+          try self.fileManager.createDirectory(at: self.downloadDirectoryURL, withIntermediateDirectories: true, attributes: nil)
         } catch {
-          self.didFailWithError(WebAppError.FileSystemFailure(reason: "Could not create download directory", underlyingError: error))
+          self.didFailWithError(WebAppError.fileSystemFailure(reason: "Could not create download directory", underlyingError: error))
           return
         }
 
-        let manifestFileURL = self.downloadDirectoryURL.URLByAppendingPathComponent("program.json")
-        if !data.writeToURL(manifestFileURL, atomically: false) {
-          self.didFailWithError(WebAppError.FileSystemFailure(reason: "Could not write asset manifest to: \(manifestFileURL)", underlyingError: error))
+        let manifestFileURL = self.downloadDirectoryURL.appendingPathComponent("program.json")
+        if !((try? data.write(to: manifestFileURL, options: [])) != nil) {
+          self.didFailWithError(WebAppError.fileSystemFailure(reason: "Could not write asset manifest to: \(manifestFileURL)", underlyingError: error))
           return
         }
 
@@ -176,23 +176,23 @@ final class AssetBundleManager: AssetBundleDownloaderDelegate {
 
     // If a new version is available, we want to know as soon as possible even
     // if other downloads are in progress
-    dataTask.priority = NSURLSessionTaskPriorityHigh
+    dataTask.priority = URLSessionTask.highPriority
     dataTask.resume()
   }
 
   /// If there is an existing Downloading directory, move it
   /// to PartialDownload and load the partiallyDownloadedAssetBundle so we
   /// don't unnecessarily redownload assets
-  private func moveExistingDownloadDirectoryIfNeeded() {
-    if fileManager.fileExistsAtPath(downloadDirectoryURL.path!) {
-      let partialDownloadDirectoryURL = self.versionsDirectoryURL.URLByAppendingPathComponent("PartialDownload")
+  fileprivate func moveExistingDownloadDirectoryIfNeeded() {
+    if fileManager.fileExists(atPath: downloadDirectoryURL.path) {
+      let partialDownloadDirectoryURL = self.versionsDirectoryURL.appendingPathComponent("PartialDownload")
       do {
-        if fileManager.fileExistsAtPath(partialDownloadDirectoryURL.path!) {
-          try fileManager.removeItemAtURL(partialDownloadDirectoryURL)
+        if fileManager.fileExists(atPath: partialDownloadDirectoryURL.path) {
+          try fileManager.removeItem(at: partialDownloadDirectoryURL)
         }
-        try fileManager.moveItemAtURL(downloadDirectoryURL, toURL: partialDownloadDirectoryURL)
+        try fileManager.moveItem(at: downloadDirectoryURL, to: partialDownloadDirectoryURL)
       } catch {
-        self.didFailWithError(WebAppError.FileSystemFailure(reason: "Could not move Downloading directory to PartialDownload", underlyingError: error))
+        self.didFailWithError(WebAppError.fileSystemFailure(reason: "Could not move Downloading directory to PartialDownload", underlyingError: error))
         return
       }
 
@@ -204,26 +204,25 @@ final class AssetBundleManager: AssetBundleDownloaderDelegate {
     }
   }
 
-  private func downloadAssetBundle(assetBundle: AssetBundle, withBaseURL baseURL: NSURL) {
+  fileprivate func downloadAssetBundle(_ assetBundle: AssetBundle, withBaseURL baseURL: URL) {
     var missingAssets = Set<Asset>()
 
     for asset in assetBundle.ownAssets {
       // Create containing directories for the asset if necessary
-      if let containingDirectoryURL = asset.fileURL.URLByDeletingLastPathComponent {
-        do {
-          try fileManager.createDirectoryAtURL(containingDirectoryURL, withIntermediateDirectories: true, attributes: nil)
-        } catch {
-          self.didFailWithError(WebAppError.FileSystemFailure(reason: "Could not create containing directories for asset", underlyingError: error))
-          return
-        }
+      let containingDirectoryURL = asset.fileURL.deletingLastPathComponent()
+      do {
+        try fileManager.createDirectory(at: containingDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+      } catch {
+        self.didFailWithError(WebAppError.fileSystemFailure(reason: "Could not create containing directories for asset", underlyingError: error))
+        return
       }
 
       // If we find a cached asset, we make a hard link to it
       if let cachedAsset = cachedAssetForAsset(asset) {
         do {
-          try fileManager.linkItemAtURL(cachedAsset.fileURL, toURL: asset.fileURL)
+          try fileManager.linkItem(at: cachedAsset.fileURL as URL, to: asset.fileURL as URL)
         } catch {
-          self.didFailWithError(WebAppError.FileSystemFailure(reason: "Could not link to cached asset", underlyingError: error))
+          self.didFailWithError(WebAppError.fileSystemFailure(reason: "Could not link to cached asset", underlyingError: error))
           return
         }
       } else {
@@ -247,15 +246,15 @@ final class AssetBundleManager: AssetBundleDownloaderDelegate {
     assetBundleDownloader!.resume()
   }
 
-  private func didFinishDownloadingAssetBundle(assetBundle: AssetBundle) {
+  fileprivate func didFinishDownloadingAssetBundle(_ assetBundle: AssetBundle) {
     delegate?.assetBundleManager(self, didFinishDownloadingBundle: assetBundle)
   }
 
-  private func didFailWithError(error: ErrorType) {
+  fileprivate func didFailWithError(_ error: Error) {
     delegate?.assetBundleManager(self, didFailDownloadingBundleWithError: error)
   }
 
-  private func cachedAssetForAsset(asset: Asset) -> Asset? {
+  fileprivate func cachedAssetForAsset(_ asset: Asset) -> Asset? {
     for assetBundle in downloadedAssetBundlesByVersion.values {
       if let cachedAsset = assetBundle.cachedAssetForURLPath(asset.URLPath, hash: asset.hash) {
         return cachedAsset
@@ -264,7 +263,7 @@ final class AssetBundleManager: AssetBundleDownloaderDelegate {
 
     if let cachedAsset = partiallyDownloadedAssetBundle?.cachedAssetForURLPath(asset.URLPath, hash: asset.hash) {
       // Make sure the asset has been downloaded
-      if fileManager.fileExistsAtPath(cachedAsset.fileURL.path!) {
+      if fileManager.fileExists(atPath: cachedAsset.fileURL.path) {
         return cachedAsset
       }
     }
@@ -273,31 +272,31 @@ final class AssetBundleManager: AssetBundleDownloaderDelegate {
   }
 
   /// Move the downloaded asset bundle to a new directory named after the version
-  private func moveDownloadedAssetBundleIntoPlace(assetBundle: AssetBundle) throws {
-    let versionDirectoryURL = self.versionsDirectoryURL.URLByAppendingPathComponent(assetBundle.version)
+  fileprivate func moveDownloadedAssetBundleIntoPlace(_ assetBundle: AssetBundle) throws {
+    let versionDirectoryURL = self.versionsDirectoryURL.appendingPathComponent(assetBundle.version)
 
     do {
-      if fileManager.fileExistsAtPath(versionDirectoryURL.path!) {
-        try fileManager.removeItemAtURL(versionDirectoryURL)
+      if fileManager.fileExists(atPath: versionDirectoryURL.path) {
+        try fileManager.removeItem(at: versionDirectoryURL)
       }
 
-      try fileManager.moveItemAtURL(assetBundle.directoryURL, toURL: versionDirectoryURL)
+      try fileManager.moveItem(at: assetBundle.directoryURL as URL, to: versionDirectoryURL)
 
       assetBundle.didMoveToDirectoryAtURL(versionDirectoryURL)
 
       downloadedAssetBundlesByVersion[assetBundle.version] = assetBundle
     } catch {
-      throw WebAppError.FileSystemFailure(reason: "Could not move downloaded asset bundle into place", underlyingError: error)
+      throw WebAppError.fileSystemFailure(reason: "Could not move downloaded asset bundle into place", underlyingError: error)
     }
   }
 
   /// Remove all downloaded asset bundles, except for one
-  func removeAllDownloadedAssetBundlesExceptFor(assetBundleToKeep: AssetBundle) throws {
-    try dispatch_sync(queue) {
+  func removeAllDownloadedAssetBundlesExceptFor(_ assetBundleToKeep: AssetBundle) throws {
+    try queue.sync {
       for assetBundle in self.downloadedAssetBundlesByVersion.values {
         if assetBundle !== assetBundleToKeep {
-          try self.fileManager.removeItemAtURL(assetBundle.directoryURL)
-          self.downloadedAssetBundlesByVersion.removeValueForKey(assetBundle.version)
+          try self.fileManager.removeItem(at: assetBundle.directoryURL)
+          self.downloadedAssetBundlesByVersion.removeValue(forKey: assetBundle.version)
         }
       }
     }
@@ -305,11 +304,11 @@ final class AssetBundleManager: AssetBundleDownloaderDelegate {
 
   // MARK: AssetBundleDownloaderDelegate
 
-  func assetBundleDownloaderDidFinish(assetBundleDownloader: AssetBundleDownloader) {
+  func assetBundleDownloaderDidFinish(_ assetBundleDownloader: AssetBundleDownloader) {
     let downloadedAssetBundle = assetBundleDownloader.assetBundle
     self.assetBundleDownloader = nil
 
-    dispatch_async(queue) {
+    queue.async {
       do {
         try self.moveDownloadedAssetBundleIntoPlace(downloadedAssetBundle)
         self.didFinishDownloadingAssetBundle(downloadedAssetBundle)
@@ -319,10 +318,10 @@ final class AssetBundleManager: AssetBundleDownloaderDelegate {
     }
   }
 
-  func assetBundleDownloader(assetBundleDownloader: AssetBundleDownloader, didFailWithError error: ErrorType) {
+  func assetBundleDownloader(_ assetBundleDownloader: AssetBundleDownloader, didFailWithError error: Error) {
     self.assetBundleDownloader = nil
 
-    dispatch_async(queue) {
+    queue.async {
       self.didFailWithError(error)
     }
   }

--- a/src/ios/AssetManifest.swift
+++ b/src/ios/AssetManifest.swift
@@ -13,35 +13,35 @@ struct AssetManifest {
   let cordovaCompatibilityVersion: String
   var entries: [Entry]
 
-  init(fileURL: NSURL) throws {
-    try self.init(data: try NSData(contentsOfURL: fileURL, options: []))
+  init(fileURL: URL) throws {
+    try self.init(data: try Data(contentsOf: fileURL, options: []))
   }
 
-  init(data: NSData) throws {
+  init(data: Data) throws {
     let JSON: JSONObject
     do {
-      JSON = try NSJSONSerialization.JSONObjectWithData(data, options: []) as! JSONObject
+      JSON = try JSONSerialization.jsonObject(with: data, options: []) as! JSONObject
     } catch {
-      throw WebAppError.InvalidAssetManifest(reason: "Error parsing asset manifest", underlyingError: error)
+      throw WebAppError.invalidAssetManifest(reason: "Error parsing asset manifest", underlyingError: error)
     }
 
-    if let format = JSON["format"] as? String where format != "web-program-pre1" {
-      throw WebAppError.InvalidAssetManifest(reason: "The asset manifest format is incompatible: \(format)", underlyingError: nil)
+    if let format = JSON["format"] as? String , format != "web-program-pre1" {
+      throw WebAppError.invalidAssetManifest(reason: "The asset manifest format is incompatible: \(format)", underlyingError: nil)
     }
 
     guard let version = JSON["version"] as? String else {
-      throw WebAppError.InvalidAssetManifest(reason: "Asset manifest does not have a version", underlyingError: nil)
+      throw WebAppError.invalidAssetManifest(reason: "Asset manifest does not have a version", underlyingError: nil)
     }
-    
+
     self.version = version
-    
+
     guard let cordovaCompatibilityVersions = JSON["cordovaCompatibilityVersions"] as? JSONObject,
       let cordovaCompatibilityVersion = cordovaCompatibilityVersions["ios"] as? String else {
-      throw WebAppError.InvalidAssetManifest(reason: "Asset manifest does not have a cordovaCompatibilityVersion", underlyingError: nil)
+      throw WebAppError.invalidAssetManifest(reason: "Asset manifest does not have a cordovaCompatibilityVersion", underlyingError: nil)
     }
-    
+
     self.cordovaCompatibilityVersion = cordovaCompatibilityVersion
-    
+
     let entriesJSON = JSON["manifest"] as? [JSONObject] ?? []
     entries = []
     for entryJSON in entriesJSON {

--- a/src/ios/Errors.swift
+++ b/src/ios/Errors.swift
@@ -1,24 +1,24 @@
-enum WebAppError: ErrorType, CustomStringConvertible {
-  case InvalidAssetManifest(reason: String, underlyingError: ErrorType?)
-  case FileSystemFailure(reason: String, underlyingError: ErrorType?)
-  case DownloadFailure(reason: String, underlyingError: ErrorType?)
-  case UnsuitableAssetBundle(reason: String, underlyingError: ErrorType?)
+enum WebAppError: Error, CustomStringConvertible {
+  case invalidAssetManifest(reason: String, underlyingError: Error?)
+  case fileSystemFailure(reason: String, underlyingError: Error?)
+  case downloadFailure(reason: String, underlyingError: Error?)
+  case unsuitableAssetBundle(reason: String, underlyingError: Error?)
 
   var description: String {
     switch self {
-    case .InvalidAssetManifest(let reason, let underlyingError):
+    case .invalidAssetManifest(let reason, let underlyingError):
       return errorMessageWithReason(reason, underlyingError: underlyingError)
-    case .FileSystemFailure(let reason, let underlyingError):
+    case .fileSystemFailure(let reason, let underlyingError):
       return errorMessageWithReason(reason, underlyingError: underlyingError)
-    case .DownloadFailure(let reason, let underlyingError):
+    case .downloadFailure(let reason, let underlyingError):
       return errorMessageWithReason(reason, underlyingError: underlyingError)
-    case .UnsuitableAssetBundle(let reason, let underlyingError):
+    case .unsuitableAssetBundle(let reason, let underlyingError):
       return errorMessageWithReason(reason, underlyingError: underlyingError)
     }
   }
 }
 
-func errorMessageWithReason(let reason: String, underlyingError: ErrorType?) -> String {
+func errorMessageWithReason(_ reason: String, underlyingError: Error?) -> String {
   if let underlyingError = underlyingError {
     return "\(reason): \(underlyingError)"
   } else {

--- a/src/ios/Utility.swift
+++ b/src/ios/Utility.swift
@@ -6,23 +6,23 @@ class Box<T>: NSObject {
   }
 }
 
-extension CollectionType {
-  func find(@noescape predicate: (Self.Generator.Element) throws -> Bool) rethrows -> Self.Generator.Element? {
-    return try indexOf(predicate).map({self[$0]})
+extension Collection {
+  func find(_ predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self.Iterator.Element? {
+    return try index(where: predicate).map({self[$0]})
   }
 }
 
-func dispatch_sync(queue: dispatch_queue_t, block: () throws -> ()) throws {
-  var caughtError: ErrorType?
-  
-  dispatch_sync(queue) {
+func dispatch_sync(_ queue: DispatchQueue, block: () throws -> ()) throws {
+  var caughtError: Error?
+
+  queue.sync {
     do {
       try block()
     } catch {
       caughtError = error
     }
   }
-  
+
   if let caughtError = caughtError {
     throw caughtError
   }
@@ -33,11 +33,11 @@ typealias JSONObject = [String:AnyObject]
 // Regex that matches the query string part of a URL
 let queryStringRegEx = try! NSRegularExpression(pattern: "(/[^?]+).*", options: [])
 
-func URLPathByRemovingQueryString(URLString: String) -> String {
+func URLPathByRemovingQueryString(_ URLString: String) -> String {
   guard let match = queryStringRegEx.firstMatchInString(URLString) else {
     return URLString
   }
-  return (URLString as NSString).substringWithRange(match.rangeAtIndex(1))
+  return (URLString as NSString).substring(with: match.rangeAt(1))
 }
 
 // Regex that matches a SHA1 hash
@@ -46,47 +46,39 @@ let sha1HashRegEx = try! NSRegularExpression(pattern: "[0-9a-f]{40}", options: [
 // Regex that matches an ETag with a SHA1 hash
 let ETagWithSha1HashRegEx = try! NSRegularExpression(pattern: "\"([0-9a-f]{40})\"", options: [])
 
-func SHA1HashFromETag(ETag: String) -> String? {
+func SHA1HashFromETag(_ ETag: String) -> String? {
   guard let match = ETagWithSha1HashRegEx.firstMatchInString(ETag) else {
     return nil
   }
-  
-  return (ETag as NSString).substringWithRange(match.rangeAtIndex(1))
+
+  return (ETag as NSString).substring(with: match.rangeAt(1))
 }
 
 extension NSRegularExpression {
-  func firstMatchInString(string: String) -> NSTextCheckingResult? {
-    return firstMatchInString(string, options: [],
+  func firstMatchInString(_ string: String) -> NSTextCheckingResult? {
+    return firstMatch(in: string, options: [],
         range: NSRange(location: 0, length: string.utf16.count))
   }
 
-  func matches(string: String) -> Bool {
+  func matches(_ string: String) -> Bool {
     return firstMatchInString(string) != nil
   }
 }
 
-extension NSURL {
+extension URL {
   var isDirectory: Bool? {
-    return resourceValueAsBoolForKey(NSURLIsDirectoryKey)
+    let values = try! self.resourceValues(forKeys: [.isDirectoryKey])
+    return values.isDirectory
   }
+
 
   var isRegularFile: Bool? {
-    return resourceValueAsBoolForKey(NSURLIsRegularFileKey)
-  }
-
-  private func resourceValueAsBoolForKey(key: String) -> Bool? {
-    do {
-      var valueObject: AnyObject?
-      try getResourceValue(&valueObject, forKey: key)
-      guard let value = valueObject?.boolValue else { return nil }
-      return value
-    } catch {
-      return nil
-    }
+    let values = try! self.resourceValues(forKeys: [.isRegularFileKey])
+    return values.isRegularFile
   }
 }
 
-extension NSHTTPURLResponse {
+extension HTTPURLResponse {
   var isSuccessful: Bool {
     return (200..<300).contains(statusCode)
   }

--- a/src/ios/WebAppConfiguration.swift
+++ b/src/ios/WebAppConfiguration.swift
@@ -1,10 +1,10 @@
 final class WebAppConfiguration {
-  let userDefaults = NSUserDefaults.standardUserDefaults()
-  
+  let userDefaults = UserDefaults.standard
+
   /// The appId as defined in the runtime config
   var appId: String? {
     get {
-      return userDefaults.stringForKey("MeteorWebAppId")
+      return userDefaults.string(forKey: "MeteorWebAppId")
     }
     set {
       let oldValue = appId
@@ -12,17 +12,17 @@ final class WebAppConfiguration {
         if oldValue != nil {
           NSLog("appId seems to have changed, new: \(newValue!), old: \(oldValue!)")
         }
-        
-        userDefaults.setObject(newValue, forKey: "MeteorWebAppId")
+
+        userDefaults.set(newValue, forKey: "MeteorWebAppId")
         userDefaults.synchronize()
       }
     }
   }
-  
+
   /// The rootURL as defined in the runtime config
-  var rootURL: NSURL? {
+  var rootURL: URL? {
     get {
-      return userDefaults.URLForKey("MeteorWebAppRootURL")
+      return userDefaults.url(forKey: "MeteorWebAppRootURL")
     }
     set {
       let oldValue = rootURL
@@ -30,61 +30,61 @@ final class WebAppConfiguration {
         if oldValue != nil {
           NSLog("ROOT_URL seems to have changed, new: \(newValue!), old: \(oldValue!)")
         }
-        
-        userDefaults.setURL(newValue, forKey: "MeteorWebAppRootURL")
+
+        userDefaults.set(newValue, forKey: "MeteorWebAppRootURL")
         userDefaults.synchronize()
       }
     }
   }
-  
+
   /// The Cordova compatibility version as specified in the asset manifest
   var cordovaCompatibilityVersion: String? {
     get {
-      return userDefaults.stringForKey("MeteorWebAppCordovaCompatibilityVersion")
+      return userDefaults.string(forKey: "MeteorWebAppCordovaCompatibilityVersion")
     }
-    
+
     set {
       if newValue != cordovaCompatibilityVersion {
         if newValue == nil {
-          userDefaults.removeObjectForKey("MeteorWebAppCordovaCompatibilityVersion")
+          userDefaults.removeObject(forKey: "MeteorWebAppCordovaCompatibilityVersion")
         } else {
-          userDefaults.setObject(newValue, forKey: "MeteorWebAppCordovaCompatibilityVersion")
+          userDefaults.set(newValue, forKey: "MeteorWebAppCordovaCompatibilityVersion")
         }
         userDefaults.synchronize()
       }
     }
   }
-  
+
   /// The last seen initial version of the asset bundle
   var lastSeenInitialVersion: String? {
     get {
-      return userDefaults.stringForKey("MeteorWebAppLastSeenInitialVersion")
+      return userDefaults.string(forKey: "MeteorWebAppLastSeenInitialVersion")
     }
-    
+
     set {
       if newValue != lastSeenInitialVersion {
         if newValue == nil {
-          userDefaults.removeObjectForKey("MeteorWebAppLastSeenInitialVersion")
+          userDefaults.removeObject(forKey: "MeteorWebAppLastSeenInitialVersion")
         } else {
-          userDefaults.setObject(newValue, forKey: "MeteorWebAppLastSeenInitialVersion")
+          userDefaults.set(newValue, forKey: "MeteorWebAppLastSeenInitialVersion")
         }
         userDefaults.synchronize()
       }
     }
   }
-  
+
   /// The last downloaded version of the asset bundle
   var lastDownloadedVersion: String? {
     get {
-      return userDefaults.stringForKey("MeteorWebAppLastDownloadedVersion")
+      return userDefaults.string(forKey: "MeteorWebAppLastDownloadedVersion")
     }
 
     set {
       if newValue != lastDownloadedVersion {
         if newValue == nil {
-          userDefaults.removeObjectForKey("MeteorWebAppLastDownloadedVersion")
+          userDefaults.removeObject(forKey: "MeteorWebAppLastDownloadedVersion")
         } else {
-          userDefaults.setObject(newValue, forKey: "MeteorWebAppLastDownloadedVersion")
+          userDefaults.set(newValue, forKey: "MeteorWebAppLastDownloadedVersion")
         }
         userDefaults.synchronize()
       }
@@ -94,16 +94,16 @@ final class WebAppConfiguration {
   /// The last kwown good version of the asset bundle
   var lastKnownGoodVersion: String? {
     get {
-      return userDefaults.stringForKey("MeteorWebAppLastKnownGoodVersion")
+      return userDefaults.string(forKey: "MeteorWebAppLastKnownGoodVersion")
     }
 
     set {
       if newValue != lastKnownGoodVersion {
-        let userDefaults = NSUserDefaults.standardUserDefaults()
+        let userDefaults = UserDefaults.standard
         if newValue == nil {
-          userDefaults.removeObjectForKey("MeteorWebAppLastKnownGoodVersion")
+          userDefaults.removeObject(forKey: "MeteorWebAppLastKnownGoodVersion")
         } else {
-          userDefaults.setObject(newValue, forKey: "MeteorWebAppLastKnownGoodVersion")
+          userDefaults.set(newValue, forKey: "MeteorWebAppLastKnownGoodVersion")
         }
         userDefaults.synchronize()
       }
@@ -113,27 +113,27 @@ final class WebAppConfiguration {
   /// Blacklisted asset bundle versions
   var blacklistedVersions: [String] {
     get {
-      return userDefaults.arrayForKey("MeteorWebAppBlacklistedVersions") as? [String] ?? []
+      return userDefaults.array(forKey: "MeteorWebAppBlacklistedVersions") as? [String] ?? []
     }
 
     set {
       if newValue != blacklistedVersions {
         if newValue.isEmpty {
-          userDefaults.removeObjectForKey("MeteorWebAppBlacklistedVersions")
+          userDefaults.removeObject(forKey: "MeteorWebAppBlacklistedVersions")
         } else {
-          userDefaults.setObject(newValue, forKey: "MeteorWebAppBlacklistedVersions")
+          userDefaults.set(newValue, forKey: "MeteorWebAppBlacklistedVersions")
         }
         userDefaults.synchronize()
       }
     }
   }
-  
-  func addBlacklistedVersion(version: String) {
+
+  func addBlacklistedVersion(_ version: String) {
     var blacklistedVersions = self.blacklistedVersions
     blacklistedVersions.append(version)
     self.blacklistedVersions = blacklistedVersions
   }
-  
+
   func reset() {
     cordovaCompatibilityVersion = nil
     lastSeenInitialVersion = nil

--- a/src/ios/WebAppLocalServer.swift
+++ b/src/ios/WebAppLocalServer.swift
@@ -8,36 +8,36 @@ let GCDWebServerRequestAttribute_FilePath = "GCDWebServerRequestAttribute_FilePa
 let localFileSystemPath = "/local-filesystem"
 
 @objc(METWebAppLocalServer)
-public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
+open class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
   /// The local web server responsible for serving assets to the web app
-  private(set) var localServer: GCDWebServer!
+  fileprivate(set) var localServer: GCDWebServer!
 
   /// The listening port of the local web server
-  private var localServerPort: UInt = 0
+  fileprivate var localServerPort: UInt = 0
 
   let authTokenKeyValuePair: String = {
-    let authToken = NSProcessInfo.processInfo().globallyUniqueString
+    let authToken = ProcessInfo.processInfo.globallyUniqueString
     return "cdvToken=\(authToken)"
   }()
 
   /// The www directory in the app bundle
-  private(set) var wwwDirectoryURL: NSURL!
+  fileprivate(set) var wwwDirectoryURL: URL!
 
   /// Persistent configuration settings for the webapp
-  private(set) var configuration: WebAppConfiguration!
+  fileprivate(set) var configuration: WebAppConfiguration!
 
   /// The asset bundle manager is responsible for managing asset bundles
   /// and checking for updates
-  private(set) var assetBundleManager: AssetBundleManager!
+  fileprivate(set) var assetBundleManager: AssetBundleManager!
 
   /// The asset bundle currently used to serve assets from
-  private var currentAssetBundle: AssetBundle! {
+  fileprivate var currentAssetBundle: AssetBundle! {
     didSet {
       if currentAssetBundle != nil {
         configuration.appId = currentAssetBundle.appId
         configuration.rootURL = currentAssetBundle.rootURL
         configuration.cordovaCompatibilityVersion = currentAssetBundle.cordovaCompatibilityVersion
-        
+
         NSLog("Serving asset bundle version: \(currentAssetBundle.version)")
       }
     }
@@ -46,7 +46,7 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
   /// Downloaded asset bundles are considered pending until the next page reload
   /// because we don't want the app to end up in an inconsistent state by
   /// loading assets from different bundles.
-  private var pendingAssetBundle: AssetBundle?
+  fileprivate var pendingAssetBundle: AssetBundle?
 
   /// Callback ID used to send a newVersionReady notification to JavaScript
   var newVersionReadyCallbackId: String?
@@ -55,43 +55,43 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
   var errorCallbackId: String?
 
   /// Timer used to wait for startup to complete after a reload
-  private var startupTimer: METTimer?
+  fileprivate var startupTimer: METTimer?
 
   /// The number of seconds to wait for startup to complete, after which
   /// we revert to the last known good version
-  private var startupTimeoutInterval: NSTimeInterval = 20.0
+  fileprivate var startupTimeoutInterval: TimeInterval = 20.0
 
-  private var isTesting: Bool = false
+  fileprivate var isTesting: Bool = false
 
   // MARK: - Lifecycle
 
   /// Called by Cordova on plugin initialization
-  override public func pluginInitialize() {
+  override open func pluginInitialize() {
     super.pluginInitialize()
 
     // Detect whether we are testing the app using
     // cordova-plugin-test-framework
     if let viewController = self.viewController as? CDVViewController
-      where viewController.startPage == "cdvtests/index.html" {
+      , viewController.startPage == "cdvtests/index.html" {
         isTesting = true
     }
 
     configuration = WebAppConfiguration()
 
-    wwwDirectoryURL = NSBundle.mainBundle().resourceURL!.URLByAppendingPathComponent("www")
+    wwwDirectoryURL = Bundle.main.resourceURL!.appendingPathComponent("www")
 
     initializeAssetBundles()
 
     // The WebAppLocalServerPort setting is currently only used for testing
-    if let portString = (commandDelegate?.settings["WebAppLocalServerPort".lowercaseString] as? String),
+    if let portString = (commandDelegate?.settings["WebAppLocalServerPort".lowercased()] as? String),
        let localServerPort = UInt(portString) {
       self.localServerPort = localServerPort
     // In all other cases, we use a listening port that has been set during build
     // and that is determined based on the appId. Hopefully this will avoid
     // collisions between Meteor apps installed on the same device
     } else if let viewController = self.viewController as? CDVViewController,
-        let port = NSURLComponents(string: viewController.startPage)?.port {
-      localServerPort = port.unsignedIntegerValue
+        let port = URLComponents(string: viewController.startPage)?.port {
+      localServerPort = UInt(port)
     }
 
     do {
@@ -101,21 +101,21 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
       return
     }
 
-    if let startupTimeoutString = (commandDelegate?.settings["WebAppStartupTimeout".lowercaseString] as? String),
+    if let startupTimeoutString = (commandDelegate?.settings["WebAppStartupTimeout".lowercased()] as? String),
        let startupTimeoutMilliseconds = UInt(startupTimeoutString) {
-      startupTimeoutInterval =  NSTimeInterval(startupTimeoutMilliseconds / 1000)
+      startupTimeoutInterval =  TimeInterval(startupTimeoutMilliseconds / 1000)
     }
 
     if !isTesting {
-      startupTimer = METTimer(queue: dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) { [weak self] in
+      startupTimer = METTimer(queue: DispatchQueue.global(priority: DispatchQueue.GlobalQueuePriority.default)) { [weak self] in
         NSLog("App startup timed out, reverting to last known good version")
         self?.revertToLastKnownGoodVersion()
       }
     }
 
-    NSNotificationCenter.defaultCenter().addObserver(self, selector: "applicationDidEnterBackground", name: UIApplicationDidEnterBackgroundNotification, object: nil)
+    NotificationCenter.default.addObserver(self, selector: #selector(WebAppLocalServer.applicationDidEnterBackground), name: NSNotification.Name.UIApplicationDidEnterBackground, object: nil)
 
-    NSNotificationCenter.defaultCenter().addObserver(self, selector: "pageDidLoad", name: CDVPageDidLoadNotification, object: webView)
+    NotificationCenter.default.addObserver(self, selector: #selector(WebAppLocalServer.pageDidLoad), name: NSNotification.Name.CDVPageDidLoad, object: webView)
   }
 
   func initializeAssetBundles() {
@@ -124,26 +124,26 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
     // The initial asset bundle consists of the assets bundled with the app
     let initialAssetBundle: AssetBundle
     do {
-      let directoryURL = wwwDirectoryURL.URLByAppendingPathComponent("application")
+      let directoryURL = wwwDirectoryURL.appendingPathComponent("application")
       initialAssetBundle = try AssetBundle(directoryURL: directoryURL)
     } catch {
       NSLog("Could not load initial asset bundle: \(error)")
       return
     }
 
-    let fileManager = NSFileManager.defaultManager()
+    let fileManager = FileManager.default
 
     // Downloaded versions are stored in Library/NoCloud/meteor
-    let libraryDirectoryURL = NSFileManager.defaultManager().URLsForDirectory(.LibraryDirectory, inDomains: .UserDomainMask).first!
-    let versionsDirectoryURL = libraryDirectoryURL.URLByAppendingPathComponent("NoCloud/meteor")
+    let libraryDirectoryURL = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first!
+    let versionsDirectoryURL = libraryDirectoryURL.appendingPathComponent("NoCloud/meteor")
 
     // If the last seen initial version is different from the currently bundled
     // version, we delete the versions directory and unset lastDownloadedVersion
     // and blacklistedVersions
     if configuration.lastSeenInitialVersion != initialAssetBundle.version {
       do {
-        if fileManager.fileExistsAtPath(versionsDirectoryURL.path!) {
-          try fileManager.removeItemAtURL(versionsDirectoryURL)
+        if fileManager.fileExists(atPath: versionsDirectoryURL.path) {
+          try fileManager.removeItem(at: versionsDirectoryURL)
         }
       } catch {
         NSLog("Could not remove versions directory: \(error)")
@@ -157,8 +157,8 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
 
     // If the versions directory does not exist, we create it
     do {
-      if !fileManager.fileExistsAtPath(versionsDirectoryURL.path!) {
-        try fileManager.createDirectoryAtURL(versionsDirectoryURL, withIntermediateDirectories: true, attributes: nil)
+      if !fileManager.fileExists(atPath: versionsDirectoryURL.path) {
+        try fileManager.createDirectory(at: versionsDirectoryURL, withIntermediateDirectories: true, attributes: nil)
       }
     } catch {
       NSLog("Could not create versions directory: \(error)")
@@ -181,7 +181,7 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
   }
 
   /// Called by Cordova before page reload
-  override public func onReset() {
+  override open func onReset() {
     super.onReset()
 
     // Clear existing callbacks
@@ -194,7 +194,7 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
       self.pendingAssetBundle = nil
     }
 
-    startupTimer?.startWithTimeInterval(startupTimeoutInterval)
+    startupTimer?.start(withTimeInterval: startupTimeoutInterval)
   }
 
   // MARK: - Notifications
@@ -210,13 +210,13 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
 
   // MARK: - Public plugin commands
 
-  public func startupDidComplete(command: CDVInvokedUrlCommand) {
+  open func startupDidComplete(_ command: CDVInvokedUrlCommand) {
     startupTimer?.stop()
 
     // If startup completed successfully, we consider a version good
     configuration.lastKnownGoodVersion = currentAssetBundle.version
 
-    commandDelegate?.runInBackground() {
+    commandDelegate?.run() {
       do {
         try self.assetBundleManager.removeAllDownloadedAssetBundlesExceptFor(self.currentAssetBundle)
       } catch {
@@ -225,61 +225,61 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
     }
 
     let result = CDVPluginResult(status: CDVCommandStatus_OK)
-    self.commandDelegate?.sendPluginResult(result, callbackId: command.callbackId)
+    self.commandDelegate?.send(result, callbackId: command.callbackId)
   }
 
-  public func checkForUpdates(command: CDVInvokedUrlCommand) {
+  open func checkForUpdates(_ command: CDVInvokedUrlCommand) {
     guard let rootURL = configuration.rootURL else {
       let errorMessage = "checkForUpdates requires a rootURL to be configured"
-      let result = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAsString: errorMessage)
-      commandDelegate?.sendPluginResult(result, callbackId: command.callbackId)
+      let result = CDVPluginResult(status: CDVCommandStatus_ERROR, messageAs: errorMessage)
+      commandDelegate?.send(result, callbackId: command.callbackId)
       return
     }
 
-    let baseURL = rootURL.URLByAppendingPathComponent("__cordova/")
+    let baseURL = rootURL.appendingPathComponent("__cordova/")
     assetBundleManager.checkForUpdatesWithBaseURL(baseURL)
 
     let result = CDVPluginResult(status: CDVCommandStatus_OK)
-    commandDelegate?.sendPluginResult(result, callbackId: command.callbackId)
+    commandDelegate?.send(result, callbackId: command.callbackId)
   }
 
-  public func onNewVersionReady(command: CDVInvokedUrlCommand) {
+  open func onNewVersionReady(_ command: CDVInvokedUrlCommand) {
     newVersionReadyCallbackId = command.callbackId
 
     let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
     // This allows us to invoke the callback later
-    result.setKeepCallbackAsBool(true)
-    commandDelegate?.sendPluginResult(result, callbackId: newVersionReadyCallbackId)
+    result?.setKeepCallbackAs(true)
+    commandDelegate?.send(result, callbackId: newVersionReadyCallbackId)
   }
 
-  private func notifyNewVersionReady(version: String?) {
+  fileprivate func notifyNewVersionReady(_ version: String?) {
     guard let newVersionReadyCallbackId = newVersionReadyCallbackId else { return }
 
-    let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAsString: version)
+    let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: version)
     // This allows us to invoke the callback later
-    result.setKeepCallbackAsBool(true)
-    commandDelegate?.sendPluginResult(result, callbackId: newVersionReadyCallbackId)
+    result?.setKeepCallbackAs(true)
+    commandDelegate?.send(result, callbackId: newVersionReadyCallbackId)
   }
 
-  public func onError(command: CDVInvokedUrlCommand) {
+  open func onError(_ command: CDVInvokedUrlCommand) {
     errorCallbackId = command.callbackId
 
     let result = CDVPluginResult(status: CDVCommandStatus_NO_RESULT)
     // This allows us to invoke the callback later
-    result.setKeepCallbackAsBool(true)
-    commandDelegate?.sendPluginResult(result, callbackId: errorCallbackId)
+    result?.setKeepCallbackAs(true)
+    commandDelegate?.send(result, callbackId: errorCallbackId)
   }
 
-  private func notifyError(error: ErrorType) {
+  fileprivate func notifyError(_ error: Error) {
     NSLog("Download failure: \(error)")
 
     guard let errorCallbackId = errorCallbackId else { return }
 
-    let errorMessage = String(error)
-    let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAsString: errorMessage)
+    let errorMessage = String(describing: error)
+    let result = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: errorMessage)
     // This allows us to invoke the callback later
-    result.setKeepCallbackAsBool(true)
-    commandDelegate?.sendPluginResult(result, callbackId: errorCallbackId)
+    result?.setKeepCallbackAs(true)
+    commandDelegate?.send(result, callbackId: errorCallbackId)
   }
 
   // MARK: - Managing Versions
@@ -312,7 +312,7 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
 
   // MARK: AssetBundleManagerDelegate
 
-  func assetBundleManager(assetBundleManager: AssetBundleManager, shouldDownloadBundleForManifest manifest: AssetManifest) -> Bool {
+  func assetBundleManager(_ assetBundleManager: AssetBundleManager, shouldDownloadBundleForManifest manifest: AssetManifest) -> Bool {
     // No need to redownload the current or the pending version
     if currentAssetBundle.version == manifest.version || pendingAssetBundle?.version == manifest.version {
       return false
@@ -320,20 +320,20 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
 
     // Don't download blacklisted versions
     if configuration.blacklistedVersions.contains(manifest.version) {
-      notifyError(WebAppError.UnsuitableAssetBundle(reason: "Skipping downloading blacklisted version", underlyingError: nil))
+      notifyError(WebAppError.unsuitableAssetBundle(reason: "Skipping downloading blacklisted version", underlyingError: nil))
       return false
     }
-    
+
     // Don't download versions potentially incompatible with the bundled native code
     if manifest.cordovaCompatibilityVersion != configuration.cordovaCompatibilityVersion {
-      notifyError(WebAppError.UnsuitableAssetBundle(reason: "Skipping downloading new version because the Cordova platform version or plugin versions have changed and are potentially incompatible", underlyingError: nil))
+      notifyError(WebAppError.unsuitableAssetBundle(reason: "Skipping downloading new version because the Cordova platform version or plugin versions have changed and are potentially incompatible", underlyingError: nil))
       return false
     }
 
     return true
   }
 
-  func assetBundleManager(assetBundleManager: AssetBundleManager, didFinishDownloadingBundle assetBundle: AssetBundle) {
+  func assetBundleManager(_ assetBundleManager: AssetBundleManager, didFinishDownloadingBundle assetBundle: AssetBundle) {
     NSLog("Finished downloading new asset bundle version: \(assetBundle.version)")
 
     configuration.lastDownloadedVersion = assetBundle.version
@@ -341,7 +341,7 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
     notifyNewVersionReady(assetBundle.version)
   }
 
-  func assetBundleManager(assetBundleManager: AssetBundleManager, didFailDownloadingBundleWithError error: ErrorType) {
+  func assetBundleManager(_ assetBundleManager: AssetBundleManager, didFailDownloadingBundleWithError error: Error) {
     notifyError(error)
   }
 
@@ -350,7 +350,7 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
   func startLocalServer() throws {
     localServer = GCDWebServer()
     // setLogLevel for some reason expects an int instead of an enum
-    GCDWebServer.setLogLevel(GCDWebServerLoggingLevel.Info.rawValue)
+    GCDWebServer.setLogLevel(GCDWebServerLoggingLevel.info.rawValue)
 
     // Handlers are added last to first
     addNotFoundHandler()
@@ -360,9 +360,9 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
     addHandlerForAssetBundle()
 
     let options = [
-      GCDWebServerOption_Port: NSNumber(unsignedInteger: localServerPort),
+      GCDWebServerOption_Port: NSNumber(value: localServerPort),
       GCDWebServerOption_BindToLocalhost: true]
-    try localServer.startWithOptions(options)
+    try localServer.start(options: options)
 
     // Set localServerPort to the assigned port, in case it is different
     localServerPort = localServer.port
@@ -376,138 +376,138 @@ public class WebAppLocalServer: METPlugin, AssetBundleManagerDelegate {
 
   // MARK: Request Handlers
 
-  private func addHandlerForAssetBundle() {
-    localServer.addHandlerWithMatchBlock({ [weak self] (requestMethod, requestURL, requestHeaders, URLPath, URLQuery) -> GCDWebServerRequest! in
+  fileprivate func addHandlerForAssetBundle() {
+    localServer.addHandler(match: { [weak self] (requestMethod, requestURL, requestHeaders, URLPath, URLQuery) -> GCDWebServerRequest! in
       if requestMethod != "GET" { return nil }
-      guard let asset = self?.currentAssetBundle?.assetForURLPath(URLPath) else { return nil }
+      guard let asset = self?.currentAssetBundle?.assetForURLPath(URLPath!) else { return nil }
 
       let request = GCDWebServerRequest(method: requestMethod, url: requestURL, headers: requestHeaders, path: URLPath, query: URLQuery)
-      request.setAttribute(Box(asset), forKey: GCDWebServerRequestAttribute_Asset)
+      request?.setAttribute(Box(asset), forKey: GCDWebServerRequestAttribute_Asset)
       return request
     }) { (request) -> GCDWebServerResponse! in
-        let asset = (request.attributeForKey(GCDWebServerRequestAttribute_Asset) as! Box<Asset>).value
-        return self.responseForAsset(request, asset: asset)
+        let asset = (request?.attribute(forKey: GCDWebServerRequestAttribute_Asset) as! Box<Asset>).value
+        return self.responseForAsset(request!, asset: asset)
     }
   }
 
-  private func addHandlerForWwwDirectory() {
-    localServer.addHandlerWithMatchBlock({ [weak self] (requestMethod, requestURL, requestHeaders, URLPath, URLQuery) -> GCDWebServerRequest! in
+  fileprivate func addHandlerForWwwDirectory() {
+    localServer.addHandler(match: { [weak self] (requestMethod, requestURL, requestHeaders, URLPath, URLQuery) -> GCDWebServerRequest! in
       if requestMethod != "GET" { return nil }
 
       // Do not serve files from /application, because these should only be served through the initial asset bundle
-      if URLPath.hasPrefix("/application") { return nil }
+      if (URLPath?.hasPrefix("/application"))! { return nil }
 
-      guard let fileURL = self?.wwwDirectoryURL?.URLByAppendingPathComponent(URLPath) else { return nil }
+      guard let fileURL = self?.wwwDirectoryURL?.appendingPathComponent(URLPath!) else { return nil }
       if fileURL.isRegularFile != true { return nil }
 
       let request = GCDWebServerRequest(method: requestMethod, url: requestURL, headers: requestHeaders, path: URLPath, query: URLQuery)
-      request.setAttribute(fileURL.path!, forKey: GCDWebServerRequestAttribute_FilePath)
+      request?.setAttribute(fileURL.path, forKey: GCDWebServerRequestAttribute_FilePath)
       return request
     }) { (request) -> GCDWebServerResponse! in
-      let filePath = request.attributeForKey(GCDWebServerRequestAttribute_FilePath) as! String
-      return self.responseForFile(request, filePath: filePath, cacheable: false)
+      let filePath = request?.attribute(forKey: GCDWebServerRequestAttribute_FilePath) as! String
+      return self.responseForFile(request!, filePath: filePath, cacheable: false)
     }
   }
 
-  private func addHandlerForLocalFileSystem() {
-    localServer.addHandlerWithMatchBlock({ (requestMethod, requestURL, requestHeaders, URLPath, URLQuery) -> GCDWebServerRequest! in
+  fileprivate func addHandlerForLocalFileSystem() {
+    localServer.addHandler(match: { (requestMethod, requestURL, requestHeaders, URLPath, URLQuery) -> GCDWebServerRequest! in
       if requestMethod != "GET" { return nil }
 
-      if !URLPath.hasPrefix(localFileSystemPath) { return nil }
+      if !(URLPath?.hasPrefix(localFileSystemPath))! { return nil }
 
-      let filePath = URLPath.substringFromIndex(localFileSystemPath.endIndex)
-      let fileURL = NSURL(fileURLWithPath: filePath)
+      let filePath = URLPath?.substring(from: localFileSystemPath.endIndex)
+      let fileURL = URL(fileURLWithPath: filePath!)
       if fileURL.isRegularFile != true { return nil }
 
       let request = GCDWebServerRequest(method: requestMethod, url: requestURL, headers: requestHeaders, path: URLPath, query: URLQuery)
-      request.setAttribute(filePath, forKey: GCDWebServerRequestAttribute_FilePath)
+      request?.setAttribute(filePath, forKey: GCDWebServerRequestAttribute_FilePath)
       return request
       }) { (request) -> GCDWebServerResponse! in
-        let filePath = request.attributeForKey(GCDWebServerRequestAttribute_FilePath) as! String
-        return self.responseForFile(request, filePath: filePath, cacheable: false)
+        let filePath = request?.attribute(forKey: GCDWebServerRequestAttribute_FilePath) as! String
+        return self.responseForFile(request!, filePath: filePath, cacheable: false)
     }
   }
 
-  private func addIndexFileHandler() {
-    localServer.addHandlerWithMatchBlock({ [weak self] (requestMethod, requestURL, requestHeaders, URLPath, URLQuery) -> GCDWebServerRequest! in
+  fileprivate func addIndexFileHandler() {
+    localServer.addHandler(match: { [weak self] (requestMethod, requestURL, requestHeaders, URLPath, URLQuery) -> GCDWebServerRequest! in
       if requestMethod != "GET" { return nil }
 
       // Don't serve index.html for local file system paths
-      if URLPath.hasPrefix(localFileSystemPath) { return nil }
+      if (URLPath?.hasPrefix(localFileSystemPath))! { return nil }
 
       if URLPath == "/favicon.ico" { return nil }
 
       guard let indexFile = self?.currentAssetBundle?.indexFile else { return nil }
 
       let request = GCDWebServerRequest(method: requestMethod, url: requestURL, headers: requestHeaders, path: URLPath, query: URLQuery)
-      request.setAttribute(Box(indexFile), forKey: GCDWebServerRequestAttribute_Asset)
+      request?.setAttribute(Box(indexFile), forKey: GCDWebServerRequestAttribute_Asset)
       return request
       }) { (request) -> GCDWebServerResponse! in
-        let asset = (request.attributeForKey(GCDWebServerRequestAttribute_Asset) as! Box<Asset>).value
-        return self.responseForAsset(request, asset: asset)
+        let asset = (request?.attribute(forKey: GCDWebServerRequestAttribute_Asset) as! Box<Asset>).value
+        return self.responseForAsset(request!, asset: asset)
     }
   }
 
-  private func addNotFoundHandler() {
-    localServer.addDefaultHandlerForMethod("GET", requestClass: GCDWebServerRequest.self) { (request) -> GCDWebServerResponse! in
-           return GCDWebServerResponse(statusCode: GCDWebServerClientErrorHTTPStatusCode.HTTPStatusCode_NotFound.rawValue)
+  fileprivate func addNotFoundHandler() {
+    localServer.addDefaultHandler(forMethod: "GET", request: GCDWebServerRequest.self) { (request) -> GCDWebServerResponse! in
+           return GCDWebServerResponse(statusCode: GCDWebServerClientErrorHTTPStatusCode.httpStatusCode_NotFound.rawValue)
     }
   }
 
-  private func responseForAsset(request: GCDWebServerRequest, asset: Asset) -> GCDWebServerResponse {
-    let filePath = asset.fileURL.path!
+  fileprivate func responseForAsset(_ request: GCDWebServerRequest, asset: Asset) -> GCDWebServerResponse {
+    let filePath = asset.fileURL.path
     return responseForFile(request, filePath: filePath, cacheable: asset.cacheable, hash: asset.hash, sourceMapURLPath: asset.sourceMapURLPath)
   }
 
-  private func responseForFile(request: GCDWebServerRequest, filePath: String, cacheable: Bool, hash: String? = nil, sourceMapURLPath: String? = nil) -> GCDWebServerResponse {
+  fileprivate func responseForFile(_ request: GCDWebServerRequest, filePath: String, cacheable: Bool, hash: String? = nil, sourceMapURLPath: String? = nil) -> GCDWebServerResponse {
     // To protect our server from access by other apps running on the same device,
     // we check whether the rponsequest contains an auth token.
     // The auth token can be passed either as a query item or as a cookie.
     // If the auth token was passed as a query item, we set the cookie.
     var shouldSetCookie = false
-    if let query = request.URL.query where query.containsString(authTokenKeyValuePair) {
+    if let query = request.url.query , query.contains(authTokenKeyValuePair) {
       shouldSetCookie = true
-    } else if let cookie = request.headers["Cookie"] where cookie.containsString(authTokenKeyValuePair) {
+    } else if let cookie = request.headers["Cookie"] , (cookie as AnyObject).contains(authTokenKeyValuePair) {
     } else {
-      return GCDWebServerResponse(statusCode: GCDWebServerClientErrorHTTPStatusCode.HTTPStatusCode_Forbidden.rawValue)
+      return GCDWebServerResponse(statusCode: GCDWebServerClientErrorHTTPStatusCode.httpStatusCode_Forbidden.rawValue)
     }
 
-    if !NSFileManager.defaultManager().fileExistsAtPath(filePath) {
+    if !FileManager.default.fileExists(atPath: filePath) {
       NSLog("File not found: \(filePath)")
-      return GCDWebServerResponse(statusCode: GCDWebServerClientErrorHTTPStatusCode.HTTPStatusCode_NotFound.rawValue)
+      return GCDWebServerResponse(statusCode: GCDWebServerClientErrorHTTPStatusCode.httpStatusCode_NotFound.rawValue)
     }
 
     // Support partial requests using byte ranges
     let response = GCDWebServerFileResponse(file: filePath, byteRange: request.byteRange)
-    response.setValue("bytes", forAdditionalHeader: "Accept-Ranges")
+    response?.setValue("bytes", forAdditionalHeader: "Accept-Ranges")
 
     if shouldSetCookie {
-      response.setValue(authTokenKeyValuePair, forAdditionalHeader: "Set-Cookie")
+      response?.setValue(authTokenKeyValuePair, forAdditionalHeader: "Set-Cookie")
     }
 
     // Only cache files when the file is cacheable and the request URL includes a cache buster
     let shouldCache = cacheable &&
-      (!(request.URL.query?.isEmpty ?? true)
-        || sha1HashRegEx.matches(request.URL.path!))
-    response.cacheControlMaxAge = UInt(shouldCache ? oneYearInSeconds : 0)
+      (!(request.url.query?.isEmpty ?? true)
+        || sha1HashRegEx.matches(request.url.path))
+    response?.cacheControlMaxAge = UInt(shouldCache ? oneYearInSeconds : 0)
 
     // If we don't set an ETag ourselves, GCDWebServerFileResponse will generate
     // one based on the inode of the file
     if let hash = hash {
-      response.eTag = hash
+      response?.eTag = hash
     }
 
     // GCDWebServerFileResponse sets this to the file modification date, which
     // isn't very useful for our purposes and would hamper
     // the ability to serve conditional requests
-    response.lastModifiedDate = nil
+    response?.lastModifiedDate = nil
 
     // If the asset has a source map, set the X-SourceMap header
     if let sourceMapURLPath = sourceMapURLPath,
-        let sourceMapURL = NSURL(string: sourceMapURLPath, relativeToURL: localServer.serverURL) {
-      response.setValue(sourceMapURL.absoluteString, forAdditionalHeader: "X-SourceMap")
+        let sourceMapURL = URL(string: sourceMapURLPath, relativeTo: localServer.serverURL) {
+      response?.setValue(sourceMapURL.absoluteString, forAdditionalHeader: "X-SourceMap")
     }
 
-    return response
+    return response!
   }
 }


### PR DESCRIPTION
This is the automatic changes Xcode 8 made when converting to swift 3, plus some manual fixes to that. I don't know for sure that this all works. In general everything seems to work in our (really complex) app, but hot reload might not be working properly. It seems like it is having trouble downloading and/or refreshing to the new version, but that may or may not be related to the changes in this PR.

When I point our app to this plugin commit, it no longer needs to change anything when you choose to convert to swift 3.0. And it builds in xcode 8 immediately without errors.

I'm guessing this should be pulled into some other branch on the main repo, but opening this PR against master (the only branch) for now.