### PR TITLE
Corrected what appears to be a logic error

### DIFF
--- a/src/android/WebAppLocalServer.java
+++ b/src/android/WebAppLocalServer.java
@@ -322,7 +322,7 @@ public class WebAppLocalServer extends CordovaPlugin implements AssetBundleManag
         }
 
         // Else, revert to the initial asset bundle, unless that is what we are currently serving
-        if (!currentAssetBundle.equals(assetBundleManager.initialAssetBundle)) {
+        else if (!currentAssetBundle.equals(assetBundleManager.initialAssetBundle)) {
             pendingAssetBundle = assetBundleManager.initialAssetBundle;
         }
 


### PR DESCRIPTION
Missing else where comment suggested one should be, tested and confirmed working on android devices. Where previously hot code push latest version was being overwritten by initial version, this logic now appears correct.