### PR TITLE
Update OkHttp dependency to 3.9.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -111,6 +111,6 @@
     <source-file src="src/android/IOUtils.java" target-dir="src/com/meteor/webapp" />
 
     <framework src="src/android/build-extras.gradle" custom="true" type="gradleReference" />
-    <framework src="com.squareup.okhttp3:okhttp:3.1.2" />
+    <framework src="com.squareup.okhttp3:okhttp:3.9.0" />
   </platform>
 </plugin>


### PR DESCRIPTION
This helps with HTTP/2 issues on latest nginx: https://trac.nginx.org/nginx/ticket/1397