### PR TITLE
Run Cordova iOS tests automatically on TravisCI.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src/ios/GCDWebServer"]
 	path = src/ios/GCDWebServer
-	url = git@github.com:meteor/GCDWebServer.git
+	url = https://github.com/meteor/GCDWebServer.git
 	branch = master

--- a/.paramedic.config.js
+++ b/.paramedic.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  platform: "ios",
+  plugins: ".",
+  action: "run",
+  verbose: true,
+  skipAppiumTests: true,
+  ci: true,
+  target: "iPhone-X\\,\\ 11\\.2",
+};

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+os: osx
+osx_image: xcode9.2
+git:
+  depth: 2
+node_js:
+  - 8
+install:
+  - npm install
+script:
+  - npm test

--- a/package.json
+++ b/package.json
@@ -21,5 +21,15 @@
     "cordova-ios"
   ],
   "author": "Meteor Development Group",
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "pretest": "ios-sim start --devicetypeid=iPhone-X",
+    "test": "cordova-paramedic --config ./.paramedic.config.js"
+  },
+  "devDependencies": {
+    "cordova": "^8.0.0",
+    "cordova-paramedic": "github:meteor/cordova-paramedic#d54206a041838d6a9a69319730bda2a14c75718e",
+    "ios-deploy": "^1.9.2",
+    "ios-sim": "^6.1.2"
+  }
 }


### PR DESCRIPTION
By using TravisCI's Mac testing environment, which comes fully-equipped
with Xcode and iOS simulators, we can run the test suite which @hwillson
revived in #46, automatically.

While many of the tests are failing, there are some passing, which seems
to prove that the testing framework is functioning properly, though
doesn't provide much assurance that we'll be able to fix the tests (though
it's likely, and I'm hopeful, that we can!).

---

More details in https://github.com/meteor/cordova-plugin-meteor-webapp/commit/5e0178cb928d1dc95e99d07b5336fb935ed4fbdb.