### PR TITLE
Switch versions explicitly

### DIFF
--- a/www/webapp_local_server.js
+++ b/www/webapp_local_server.js
@@ -28,6 +28,19 @@ module.exports = {
       []);
   },
 
+  switchToPendingVersion: function(callback, errorCallback = Function.prototype) {
+    cordova.exec(
+      callback,
+      (error) => {
+        console.error(error);
+        errorCallback(error);
+      },
+      "WebAppLocalServer",
+      "switchPendingVersion",
+      []
+    );
+  },
+
   onError: function(callback) {
     cordova.exec(
       function(errorMessage) {

--- a/www/webapp_local_server.js
+++ b/www/webapp_local_server.js
@@ -28,12 +28,14 @@ module.exports = {
       []);
   },
 
-  switchToPendingVersion: function(callback, errorCallback = Function.prototype) {
+  switchToPendingVersion: function(callback, errorCallback) {
     cordova.exec(
       callback,
       (error) => {
         console.error(error);
-        errorCallback(error);
+        if (typeof errorCallback === "function") {
+          errorCallback(error);
+        }
       },
       "WebAppLocalServer",
       "switchPendingVersion",


### PR DESCRIPTION
This changes switching versions to be done explicitly with call to  `WebAppLocalServer.switchToPendingVersion` instead of trying to switch every time a browser reload is detected.

This is another part of extracted fixes from @matdurand's commits.

This and the other PRs were running on production in my company's fork more than 1 year now.

Refs:
#48
meteor/meteor#8063 (comment)

Fixes: https://github.com/meteor/cordova-plugin-meteor-webapp/issues/29


