### PR TITLE
Android build.extras.gradle fix

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -16,7 +16,7 @@
        specific language governing permissions and limitations
        under the License.
  */
-ext.postBuildExtras = {
+cdvPluginPostBuildExtras.add({
     def inAssetsDir = file("assets")
     def outAssetsDir = inAssetsDir
     def outFile = new File(outAssetsDir, "cdvasset.manifest")
@@ -44,4 +44,4 @@ ext.postBuildExtras = {
     newTask.outputs.file outFile
     def preBuildTask = tasks["preBuild"]
     preBuildTask.dependsOn(newTask)
-}
+})


### PR DESCRIPTION
Android build.extras.gradle fix. Using "cdvPluginPostBuildExtras.add" instead of assigning commands to "ext.postBuildExtras" in order to fix overwrites of "ext.postBuildExtras" by other Cordova plugins.