### PR TITLE
Read/write cdvasset.manifest from/to correct assets directory.

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -17,7 +17,11 @@
        under the License.
  */
 cdvPluginPostBuildExtras.add({
-    def inAssetsDir = file("assets")
+    def inAssetsDir = file("src/main/assets")
+    if (!inAssetsDir.exists()) {
+        // Backwards compatibility for cordova-android < 7.0.0:
+        inAssetsDir = file("assets");
+    }
     def outAssetsDir = inAssetsDir
     def outFile = new File(outAssetsDir, "cdvasset.manifest")
 

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -20,7 +20,7 @@ cdvPluginPostBuildExtras.add({
     def inAssetsDir = file("src/main/assets")
     if (!inAssetsDir.exists()) {
         // Backwards compatibility for cordova-android < 7.0.0:
-        inAssetsDir = file("assets");
+        inAssetsDir = file("assets")
     }
     def outAssetsDir = inAssetsDir
     def outFile = new File(outAssetsDir, "cdvasset.manifest")


### PR DESCRIPTION
After updating to `cordova-android@7.1.4` (from 6.4.0) I started seeing the following error when running `meteor run android`:
```
MeteorWebApp: Could not load asset manager cache
MeteorWebApp: java.io.FileNotFoundException: cdvasset.manifest
```
Since anyone trying to write the `cdvasset.manifest` file probably also needs to invoke the rather uniquely-named `cdvCreateAssetManifest` task (see the file changed by this PR, `build-extras.gradle`), I googled that, and eventually came across this [`build-extras.gradle` file](https://github.com/Microsoft/cordova-plugin-code-push/blob/79f3635a8711c767d6067ca18d8ca516df23e716/src/android/build-extras.gradle#L24-L27
) from another Cordova plugin project.

These files are almost the same, except for the way `inAssetsDir` is defined, and the comment about supporting `cordova-android` <7.0.0 was another tip-off that I should try using `file("src/main/assets")` instead of just `file("assets")`.

Although I can't claim I understand every detail of what's happening here, the new code falls back to doing what it did before when `src/main/assets` does not exist, so I think it's a relatively conservative change.