### PR TITLE
FIX - Issue #72

### DIFF
--- a/www/webapp_local_server.js
+++ b/www/webapp_local_server.js
@@ -31,7 +31,7 @@ module.exports = {
   switchToPendingVersion: function(callback, errorCallback) {
     cordova.exec(
       callback,
-      (error) => {
+      function(error) {
         console.error(error);
         if (typeof errorCallback === "function") {
           errorCallback(error);


### PR DESCRIPTION
Replace fat-arrow (ES6) function with regular (ES5) function for backwards compatibility on Android 4.4.x devices.

Fixes issue #72 