### PR TITLE
HCP for android emulator

### DIFF
--- a/src/android/AssetBundle.java
+++ b/src/android/AssetBundle.java
@@ -191,7 +191,10 @@ class AssetBundle {
             JSONObject runtimeConfig = getRuntimeConfig();
             if (runtimeConfig != null) {
                 try {
-                    rootUrlString = runtimeConfig.getString("ROOT_URL").replace("localhost","10.0.2.2");
+                    const localhost = "localhost";
+                    const emulatorHostLoopbackAddr = "10.0.2.2";
+                    let rootUrlStringOrig = runtimeConfig.getString("ROOT_URL");                   
+                    rootUrlString = rootUrlStringOrig.replace( localhost, emulatorHostLoopbackAddr );
                 } catch (JSONException e) {
                     Log.w(LOG_TAG, "Error reading ROOT_URL from runtime config", e);
                 }


### PR DESCRIPTION
I made this change to get HCP to work in the android emulator. I think it's safe, given that it doesn't do anything unless this is android and "localhost" is present in the ROOT_URL string, which means it has to be the emulator -- right? The idea was taken straight from code that runs elsewhere that deals with the 10.0.2.2 android issue.