### PR TITLE
The Task.leftShift(Closure) method has been deprecated 

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -25,24 +25,26 @@ cdvPluginPostBuildExtras.add({
     def outAssetsDir = inAssetsDir
     def outFile = new File(outAssetsDir, "cdvasset.manifest")
 
-    def newTask = task("cdvCreateAssetManifest") << {
-        def contents = new HashMap()
-        def sizes = new HashMap()
-        contents[""] = inAssetsDir.list()
-        def tree = fileTree(dir: inAssetsDir)
-        tree.visit { fileDetails ->
-            if (fileDetails.isDirectory()) {
+    def newTask = task("cdvCreateAssetManifest") {
+      doLast  {
+          def contents = new HashMap()
+          def sizes = new HashMap()
+          contents[""] = inAssetsDir.list()
+          def tree = fileTree(dir: inAssetsDir)
+          tree.visit { fileDetails ->
+              if (fileDetails.isDirectory()) {
                 contents[fileDetails.relativePath.toString()] = fileDetails.file.list()
-            } else {
+              } else {
                 sizes[fileDetails.relativePath.toString()] = fileDetails.file.length()
-            }
-        }
+              }
+          }
 
-        outAssetsDir.mkdirs()
-        outFile.withObjectOutputStream { oos ->
+          outAssetsDir.mkdirs()
+          outFile.withObjectOutputStream { oos ->
             oos.writeObject(contents)
             oos.writeObject(sizes)
-        }
+          }
+      }
     }
     newTask.inputs.dir inAssetsDir
     newTask.outputs.file outFile


### PR DESCRIPTION
For Gradle 5.0 and above the leftshift method has been deprecated and planned to be removed in up coming release.
Even while building in android studio it gives error like this. So making PR to keep it upto date.
![1_IWFok_gbaUeotNL0p0j9yw](https://user-images.githubusercontent.com/8859335/72000543-89054400-3269-11ea-8957-36f3214937fd.png)
 
