### PR TITLE
Upgrade to cordova-android 10 - use WebviewAssetLoader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-meteor-webapp",
-  "version": "1.9.1",
+  "version": "2.0.0-beta.0",
   "description": "Cordova plugin that serves a Meteor web app through a local server and implements hot code push",
   "cordova": {
     "id": "cordova-plugin-meteor-webapp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-meteor-webapp",
-  "version": "2.0.0-beta.0",
+  "version": "2.0.0-beta.1",
   "description": "Cordova plugin that serves a Meteor web app through a local server and implements hot code push",
   "cordova": {
     "id": "cordova-plugin-meteor-webapp",

--- a/plugin.xml
+++ b/plugin.xml
@@ -110,6 +110,7 @@
     <source-file src="src/android/IOUtils.java" target-dir="src/com/meteor/webapp" />
 
     <framework src="src/android/build-extras.gradle" custom="true" type="gradleReference" />
+    <framework src="androidx.webkit:webkit:1.3.0" type="gradleReference" />
     <framework src="com.squareup.okhttp3:okhttp:3.9.1" />
   </platform>
 </plugin>


### PR DESCRIPTION
Use WebViewAssetLoader on Android with newest cordova AndroidX webview system instead of the old remapUri approach.

The remapUri method is not called anymore, as on latest cordova-android the webviewassetloader is used by default